### PR TITLE
feat: Create /docs structure for GitHub Pages

### DIFF
--- a/docs/.keep
+++ b/docs/.keep
@@ -1,0 +1,1 @@
+# This is a placeholder file to ensure the docs directory is tracked by Git.

--- a/docs/compare.html
+++ b/docs/compare.html
@@ -1,0 +1,385 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Compare Scenarios - FIRE Calculator</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <link rel="stylesheet" href="static/css/main.css">
+</head>
+<body>
+  <script src="static/js/theme.js"></script>
+  <script>applyTheme();</script>
+  <header>
+    <div>Compare Scenarios</div>
+    <div class="header-right">
+      <button class="theme-toggle" onclick="toggleTheme()">Toggle Theme</button>
+      <a href="/settings" class="settings-link">&#9776;</a>
+    </div>
+  </header>
+  <div class="container compare-page"> <!-- .compare-page class is already here -->
+    <h2>Enter Comparison Scenarios</h2>
+    <div class="scenario-header">
+      <label for="scenarioCount">Number of Scenarios:</label>
+      <select id="scenarioCount">
+        <option value="1">1</option>
+        <option value="2" selected>2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+      </select>
+      &nbsp;&nbsp;
+      <button type="button" onclick="saveScenarios()">Save Scenarios</button>
+      &nbsp;&nbsp;
+      <select id="loadScenarioSelect" onchange="loadScenario()"></select>
+    </div>
+    <form method="post" action="/compare" id="compareForm">
+      <div class="scenario-container">
+        <!-- {% for n in range(1,5) %} -->
+        <!-- Scenario 1 -->
+        <div class="scenario" id="scenario1">
+          <h3>Scenario 1</h3>
+          <div class="form-group">
+            <label for="scenario1_W_slider">Annual Expenses (W):</label>
+            <input type="range" id="scenario1_W_slider" name="scenario1_W" min="0" max="1000000" step="1000" value="50000"> <!-- {{ request.form.get('scenario1_W', '') }} -->
+            <input type="number" id="scenario1_W_input" class="number-input" name="scenario1_W" value="50000" placeholder="e.g., 50000"> <!-- {{ request.form.get('scenario1_W', '') }} -->
+          </div>
+          <div class="form-group">
+            <label for="scenario1_r_slider">Expected Annual Return (%):</label>
+            <input type="range" id="scenario1_r_slider" name="scenario1_r" min="0" max="15" step="0.01" value="7"> <!-- {{ request.form.get('scenario1_r', '') }} -->
+            <input type="number" id="scenario1_r_input" class="number-input" name="scenario1_r" value="7" placeholder="e.g., 7"> <!-- {{ request.form.get('scenario1_r', '') }} -->
+          </div>
+          <div class="form-group">
+            <label for="scenario1_i_slider">Expected Annual Inflation (%):</label>
+            <input type="range" id="scenario1_i_slider" name="scenario1_i" min="0" max="10" step="0.01" value="3"> <!-- {{ request.form.get('scenario1_i', '') }} -->
+            <input type="number" id="scenario1_i_input" class="number-input" name="scenario1_i" value="3" placeholder="e.g., 2"> <!-- {{ request.form.get('scenario1_i', '') }} -->
+          </div>
+          <div class="form-group">
+            <label for="scenario1_T_slider">Retirement Duration (years):</label>
+            <input type="range" id="scenario1_T_slider" name="scenario1_T" min="10" max="100" step="1" value="30"> <!-- {{ request.form.get('scenario1_T', '') }} -->
+            <input type="number" id="scenario1_T_input" class="number-input" name="scenario1_T" value="30" placeholder="e.g., 30"> <!-- {{ request.form.get('scenario1_T', '') }} -->
+          </div>
+          <div class="form-group">
+            <label>Withdrawal Timing:</label>
+            <input type="radio" name="scenario1_withdrawal_time" value="start" checked> <!-- {% if request.form.get('scenario1_withdrawal_time', 'start') == 'start' %}checked{% endif %} --> Start of Year
+            <input type="radio" name="scenario1_withdrawal_time" value="end"> <!-- {% if request.form.get('scenario1_withdrawal_time', 'start') == 'end' %}checked{% endif %} --> End of Year
+          </div>
+          <div class="form-group">
+            <label for="scenario1_D">Desired Final Portfolio Value ($):</label>
+            <input type="number" name="scenario1_D" id="scenario1_D" value="0.0" step="any" min="0">
+          </div>
+          <div class="form-group">
+            <label>Enable Scenario 1:</label>
+            <input type="checkbox" name="scenario1_enabled" checked> <!-- {% if request.form.get('scenario1_enabled') == "on" or n == 1 %}checked{% endif %} -->
+          </div>
+          <!-- {% if scenarios and scenarios|length >= 1 and scenarios[0].enabled %}
+          <div class="result-section">
+            <p><strong>FIRE Number:</strong> ${{ "{:,.2f}".format(scenarios[0].fire_number) }}</p>
+          </div>
+          {% endif %} -->
+        </div>
+        <!-- Scenario 2 -->
+        <div class="scenario" id="scenario2">
+          <h3>Scenario 2</h3>
+          <div class="form-group">
+            <label for="scenario2_W_slider">Annual Expenses (W):</label>
+            <input type="range" id="scenario2_W_slider" name="scenario2_W" min="0" max="1000000" step="1000" value=""> <!-- {{ request.form.get('scenario2_W', '') }} -->
+            <input type="number" id="scenario2_W_input" class="number-input" name="scenario2_W" value="" placeholder="e.g., 50000"> <!-- {{ request.form.get('scenario2_W', '') }} -->
+          </div>
+          <div class="form-group">
+            <label for="scenario2_r_slider">Expected Annual Return (%):</label>
+            <input type="range" id="scenario2_r_slider" name="scenario2_r" min="0" max="15" step="0.01" value=""> <!-- {{ request.form.get('scenario2_r', '') }} -->
+            <input type="number" id="scenario2_r_input" class="number-input" name="scenario2_r" value="" placeholder="e.g., 7"> <!-- {{ request.form.get('scenario2_r', '') }} -->
+          </div>
+          <div class="form-group">
+            <label for="scenario2_i_slider">Expected Annual Inflation (%):</label>
+            <input type="range" id="scenario2_i_slider" name="scenario2_i" min="0" max="10" step="0.01" value=""> <!-- {{ request.form.get('scenario2_i', '') }} -->
+            <input type="number" id="scenario2_i_input" class="number-input" name="scenario2_i" value="" placeholder="e.g., 2"> <!-- {{ request.form.get('scenario2_i', '') }} -->
+          </div>
+          <div class="form-group">
+            <label for="scenario2_T_slider">Retirement Duration (years):</label>
+            <input type="range" id="scenario2_T_slider" name="scenario2_T" min="10" max="100" step="1" value=""> <!-- {{ request.form.get('scenario2_T', '') }} -->
+            <input type="number" id="scenario2_T_input" class="number-input" name="scenario2_T" value="" placeholder="e.g., 30"> <!-- {{ request.form.get('scenario2_T', '') }} -->
+          </div>
+          <div class="form-group">
+            <label>Withdrawal Timing:</label>
+            <input type="radio" name="scenario2_withdrawal_time" value="start" checked> <!-- {% if request.form.get('scenario2_withdrawal_time', 'start') == 'start' %}checked{% endif %} --> Start of Year
+            <input type="radio" name="scenario2_withdrawal_time" value="end"> <!-- {% if request.form.get('scenario2_withdrawal_time', 'start') == 'end' %}checked{% endif %} --> End of Year
+          </div>
+          <div class="form-group">
+            <label for="scenario2_D">Desired Final Portfolio Value ($):</label>
+            <input type="number" name="scenario2_D" id="scenario2_D" value="0.0" step="any" min="0">
+          </div>
+          <div class="form-group">
+            <label>Enable Scenario 2:</label>
+            <input type="checkbox" name="scenario2_enabled" checked> <!-- {% if request.form.get('scenario2_enabled') == "on" or n == 1 %}checked{% endif %} -->
+          </div>
+          <!-- {% if scenarios and scenarios|length >= 2 and scenarios[1].enabled %}
+          <div class="result-section">
+            <p><strong>FIRE Number:</strong> ${{ "{:,.2f}".format(scenarios[1].fire_number) }}</p>
+          </div>
+          {% endif %} -->
+        </div>
+        <!-- Add similar blocks for scenario3 and scenario4, removing Jinja and setting default values -->
+        <!-- Scenario 3 (template) -->
+        <div class="scenario" id="scenario3" style="display:none;">
+          <h3>Scenario 3</h3>
+          <div class="form-group">
+            <label for="scenario3_W_slider">Annual Expenses (W):</label>
+            <input type="range" id="scenario3_W_slider" name="scenario3_W" min="0" max="1000000" step="1000" value="">
+            <input type="number" id="scenario3_W_input" class="number-input" name="scenario3_W" value="" placeholder="e.g., 50000">
+          </div>
+          <div class="form-group">
+            <label for="scenario3_r_slider">Expected Annual Return (%):</label>
+            <input type="range" id="scenario3_r_slider" name="scenario3_r" min="0" max="15" step="0.01" value="">
+            <input type="number" id="scenario3_r_input" class="number-input" name="scenario3_r" value="" placeholder="e.g., 7">
+          </div>
+          <div class="form-group">
+            <label for="scenario3_i_slider">Expected Annual Inflation (%):</label>
+            <input type="range" id="scenario3_i_slider" name="scenario3_i" min="0" max="10" step="0.01" value="">
+            <input type="number" id="scenario3_i_input" class="number-input" name="scenario3_i" value="" placeholder="e.g., 2">
+          </div>
+          <div class="form-group">
+            <label for="scenario3_T_slider">Retirement Duration (years):</label>
+            <input type="range" id="scenario3_T_slider" name="scenario3_T" min="10" max="100" step="1" value="">
+            <input type="number" id="scenario3_T_input" class="number-input" name="scenario3_T" value="" placeholder="e.g., 30">
+          </div>
+          <div class="form-group">
+            <label>Withdrawal Timing:</label>
+            <input type="radio" name="scenario3_withdrawal_time" value="start" checked> Start of Year
+            <input type="radio" name="scenario3_withdrawal_time" value="end"> End of Year
+          </div>
+          <div class="form-group">
+            <label for="scenario3_D">Desired Final Portfolio Value ($):</label>
+            <input type="number" name="scenario3_D" id="scenario3_D" value="0.0" step="any" min="0">
+          </div>
+          <div class="form-group">
+            <label>Enable Scenario 3:</label>
+            <input type="checkbox" name="scenario3_enabled">
+          </div>
+        </div>
+        <!-- Scenario 4 (template) -->
+        <div class="scenario" id="scenario4" style="display:none;">
+          <h3>Scenario 4</h3>
+          <div class="form-group">
+            <label for="scenario4_W_slider">Annual Expenses (W):</label>
+            <input type="range" id="scenario4_W_slider" name="scenario4_W" min="0" max="1000000" step="1000" value="">
+            <input type="number" id="scenario4_W_input" class="number-input" name="scenario4_W" value="" placeholder="e.g., 50000">
+          </div>
+          <div class="form-group">
+            <label for="scenario4_r_slider">Expected Annual Return (%):</label>
+            <input type="range" id="scenario4_r_slider" name="scenario4_r" min="0" max="15" step="0.01" value="">
+            <input type="number" id="scenario4_r_input" class="number-input" name="scenario4_r" value="" placeholder="e.g., 7">
+          </div>
+          <div class="form-group">
+            <label for="scenario4_i_slider">Expected Annual Inflation (%):</label>
+            <input type="range" id="scenario4_i_slider" name="scenario4_i" min="0" max="10" step="0.01" value="">
+            <input type="number" id="scenario4_i_input" class="number-input" name="scenario4_i" value="" placeholder="e.g., 2">
+          </div>
+          <div class="form-group">
+            <label for="scenario4_T_slider">Retirement Duration (years):</label>
+            <input type="range" id="scenario4_T_slider" name="scenario4_T" min="10" max="100" step="1" value="">
+            <input type="number" id="scenario4_T_input" class="number-input" name="scenario4_T" value="" placeholder="e.g., 30">
+          </div>
+          <div class="form-group">
+            <label>Withdrawal Timing:</label>
+            <input type="radio" name="scenario4_withdrawal_time" value="start" checked> Start of Year
+            <input type="radio" name="scenario4_withdrawal_time" value="end"> End of Year
+          </div>
+          <div class="form-group">
+            <label for="scenario4_D">Desired Final Portfolio Value ($):</label>
+            <input type="number" name="scenario4_D" id="scenario4_D" value="0.0" step="any" min="0">
+          </div>
+          <div class="form-group">
+            <label>Enable Scenario 4:</label>
+            <input type="checkbox" name="scenario4_enabled">
+          </div>
+        </div>
+        <!-- {% endfor %} -->
+      </div>
+      <input type="submit" value="Compare Scenarios">
+    </form>
+    
+    <div id="summaryTable"></div>
+    
+    <div id="combinedGraphs">
+      <!-- {% if combined_balance and combined_withdrawal %}
+        <h3>Combined Portfolio Balance</h3>
+        <div id="combined_balance">{{ combined_balance|safe }}</div>
+        <h3>Combined Annual Withdrawals</h3>
+        <div id="combined_withdrawal">{{ combined_withdrawal|safe }}</div>
+      {% endif %} -->
+      <p>Combined graphs will appear here.</p>
+    </div>
+    
+    <!-- {% if message %}
+      <p style="color: red; text-align: center;">{{ message }}</p>
+    {% endif %} -->
+    
+    <a href="/">← Back to Calculator</a>
+  </div>
+  
+  <script>
+    function updateScenarioDisplay() {
+      var count = parseInt($("#scenarioCount").val());
+      $(".scenario").each(function(index) {
+        if (index < count) {
+          $(this).show();
+        } else {
+          $(this).hide();
+        }
+      });
+    }
+    $(document).ready(function(){
+      updateScenarioDisplay();
+      $("#scenarioCount").on("change", updateScenarioDisplay);
+      $(".scenario-container").sortable({ placeholder: "ui-state-highlight" });
+      loadScenarioOptions();
+    });
+    
+    function saveScenarios() {
+      var data = $("#compareForm").serializeArray();
+      var scenarioData = {};
+      data.forEach(function(item) {
+        scenarioData[item.name] = item.value;
+      });
+      var scenarioName = prompt("Enter a name for this scenario configuration:");
+      if(scenarioName) {
+        localStorage.setItem("compareScenario_" + scenarioName, JSON.stringify(scenarioData));
+        loadScenarioOptions();
+        alert("Scenario saved as '" + scenarioName + "'.");
+      }
+    }
+    
+    function loadScenarioOptions() {
+      var options = "";
+      for(var key in localStorage) {
+        if(key.startsWith("compareScenario_")) {
+          var name = key.replace("compareScenario_", "");
+          options += "<option value='" + key + "'>" + name + "</option>";
+        }
+      }
+      $("#loadScenarioSelect").html(options);
+    }
+    
+    function loadScenario() {
+      var key = $("#loadScenarioSelect").val();
+      if(key) {
+        var data = JSON.parse(localStorage.getItem(key));
+        for(var prop in data) {
+          var field = $("[name='" + prop + "']");
+          if(field.attr("type") === "checkbox") {
+            field.prop("checked", data[prop] === "on");
+          } else {
+            field.val(data[prop]);
+          }
+        }
+        updateComparison();
+      }
+    }
+    
+    function updateComparison() {
+      $.ajax({
+        type: "POST",
+        url: "/compare",
+        data: $("#compareForm").serialize(),
+        headers: { "X-Requested-With": "XMLHttpRequest" },
+        success: function(response) {
+          if(response.message) {
+            $("#combinedGraphs").html("");
+            alert(response.message);
+          } else {
+            $("#combinedGraphs").html(
+              "<h3>Combined Portfolio Balance</h3>" +
+              response.combined_balance +
+              "<h3>Combined Annual Withdrawals</h3>" +
+              response.combined_withdrawal
+            );
+            updateSummaryTable(response.scenarios);
+            response.scenarios.forEach(function(sc) {
+              $("#scenario" + sc.n).find(".result-section").remove();
+              var resultHtml = '<div class="result-section"><p><strong>FIRE Number:</strong> $' + sc.fire_number.toFixed(2) + '</p></div>';
+              $("#scenario" + sc.n).append(resultHtml);
+            });
+          }
+        },
+        error: function() {
+          console.error("Error updating comparison data.");
+        }
+      });
+    }
+    
+    function updateSummaryTable(scenarios) {
+      var html = "<table><thead><tr><th>Scenario</th><th>W</th><th>Return (%)</th><th>Inflation (%)</th><th>T</th><th>Withdrawal Timing</th><th>FIRE Number</th></tr></thead><tbody>";
+      scenarios.forEach(function(sc) {
+        html += "<tr><td>" + sc.n + "</td>" +
+                "<td>" + sc.W + "</td>" +
+                "<td>" + sc.r_perc + "</td>" +  // Corrected
+                "<td>" + sc.i_perc + "</td>" +  // Corrected
+                "<td>" + sc.T + "</td>" +
+                "<td>" + sc.withdrawal_time + "</td>" +
+                "<td>$" + sc.fire_number.toFixed(2) + "</td></tr>";
+      });
+      html += "</tbody></table>";
+      $("#summaryTable").html(html);
+    }
+    
+    function bindScenarioSync(n) {
+      $("#scenario" + n + "_W_slider").on("input", function(){
+        $("#scenario" + n + "_W_input").val($(this).val());
+        updateComparison();
+      });
+      $("#scenario" + n + "_r_slider").on("input", function(){
+        $("#scenario" + n + "_r_input").val($(this).val());
+        updateComparison();
+      });
+      $("#scenario" + n + "_i_slider").on("input", function(){
+        $("#scenario" + n + "_i_input").val($(this).val());
+        updateComparison();
+      });
+      $("#scenario" + n + "_T_slider").on("input", function(){
+        $("#scenario" + n + "_T_input").val($(this).val());
+        updateComparison();
+      });
+      
+      $("#scenario" + n + "_W_input").on("change", function(){
+        $("#scenario" + n + "_W_slider").val($(this).val());
+        updateComparison();
+      });
+      $("#scenario" + n + "_r_input").on("change", function(){
+        $("#scenario" + n + "_r_slider").val($(this).val());
+        updateComparison();
+      });
+      $("#scenario" + n + "_i_input").on("change", function(){
+        $("#scenario" + n + "_i_slider").val($(this).val());
+        updateComparison();
+      });
+      $("#scenario" + n + "_T_input").on("change", function(){
+        $("#scenario" + n + "_T_slider").val($(this).val());
+        updateComparison();
+      });
+      
+      $("input[name='scenario" + n + "_withdrawal_time']").on("change", function(){
+        updateComparison();
+      });
+      
+      $("input[name='scenario" + n + "_enabled']").on("change", function(){
+        updateComparison();
+      });
+    }
+    
+    $(document).ready(function(){
+      for(var n = 1; n <= 4; n++){
+        bindScenarioSync(n);
+      }
+      $("#compareForm").on("submit", function(e){
+        e.preventDefault();
+        updateComparison();
+      });
+      loadScenarioOptions();
+    });
+  </script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>FIRE Calculator</title>
+  <link rel="stylesheet" href="static/css/main.css">
+</head>
+<body>
+  <script src="static/js/theme.js"></script>
+  <script>applyTheme();</script>
+  <header>
+    <div>FIRE Calculator</div>
+    <div class="header-right">
+      <button class="theme-toggle" onclick="toggleTheme()">Toggle Theme</button>
+      <a href="/settings" class="settings-link">&#9776;</a>
+    </div>
+  </header>
+  <div class="container index-page"> <!-- .index-page class is already here -->
+    <h2>Enter Your Details</h2>
+    <form method="post" action="/">
+      <div class="form-group">
+        <label for="W">Annual Expenses (in today's dollars):</label>
+        <input type="number" name="W" id="W" required>
+      </div>
+      <div class="form-group">
+        <label for="r">Expected Annual Return (%):</label>
+        <input type="number" name="r" id="r" step="0.1" required>
+      </div>
+      <div class="form-group">
+        <label for="i">Expected Annual Inflation (%):</label>
+        <input type="number" name="i" id="i" step="0.1" required>
+      </div>
+      <div class="form-group">
+        <label for="T">Retirement Duration (years):</label>
+        <input type="number" name="T" id="T" required>
+      </div>
+      <div class="form-group radio-group">
+        <label>Withdrawal Timing:</label>
+        <input type="radio" name="withdrawal_time" value="start" id="start" <!-- {% if withdrawal_time == 'start' or not withdrawal_time %}checked{% endif %} --> checked>
+        <label for="start" style="display:inline;">Start of Year</label>
+        <input type="radio" name="withdrawal_time" value="end" id="end" <!-- {% if withdrawal_time == 'end' %}checked{% endif %} -->>
+        <label for="end" style="display:inline;">End of Year</label>
+      </div>
+      <div class="form-group">
+        <label for="D">Desired Final Portfolio Value ($):</label>
+        <input type="number" name="D" id="D" value="0.0" step="any" min="0">
+        <small>Optional. The portfolio value you want remaining at the end of the term.</small>
+      </div>
+      <input type="submit" value="Calculate">
+    </form>
+    <br>
+    <a href="/compare">Compare Scenarios</a>
+  </div>
+</body>
+</html>

--- a/docs/result.html
+++ b/docs/result.html
@@ -1,0 +1,427 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>FIRE Calculator Results</title>
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script> <!-- Plotly is used -->
+  <link rel="stylesheet" href="static/css/main.css">
+</head>
+<body>
+  <script>
+    // This script block is for page-specific JS. Theme JS will be linked.
+  </script>
+  <script src="static/js/theme.js"></script>
+  <script>applyTheme();</script>
+  <header>
+    <div class="header-left">FIRE Calculator Results</div>
+    <div class="header-right">
+      <button class="theme-toggle" onclick="toggleTheme()">Toggle Theme</button>
+      <a href="/settings" class="settings-link">&#9776;</a>
+    </div>
+  </header>
+
+  <div id="exportParamsContainer"
+       data-w="<!-- {{ fire_W_input_val | default(0) }} -->0"
+       data-r="<!-- {{ r_form_val | default(0) }} -->0"
+       data-i="<!-- {{ i_form_val | default(0) }} -->0"
+       data-t="<!-- {{ T_form_val | default(0) }} -->30"
+       data-withdrawal-time="<!-- {{ withdrawal_time_form_val | default(TIME_END_const) }} -->end"
+       data-mode="<!-- {{ initial_mode_from_index | default(MODE_WITHDRAWAL_const) }} -->withdrawal"
+       data-p="<!-- {{ P_input_raw_for_js | default(0) }} -->0"
+       data-d="<!-- {{ D_form_val | default(0.0) }} -->0.0">
+      <a href="#" id="exportCsvLink" class="export-btn" download="fire_results.csv" style="margin-top: 10px; margin-bottom: 10px;">Export to CSV</a>
+  </div>
+
+  <div style="text-align: center; margin: 15px 0;">
+    <!-- {% if D_form_val and D_form_val > 0 %}
+    <p style="font-weight: bold; background-color: rgba(255, 229, 180, 0.5); padding: 8px; border-radius: 5px;">
+      Calculations aim for a Desired Final Portfolio Value of: <strong>${{ "{:,.2f}".format(D_form_val) }}</strong>
+    </p>
+    {% endif %} -->
+    <span class="info-icon global-info">&#9432;
+      <span class="tooltip-text">Adjust any slider or enter a value – both modes update simultaneously. The graphs and values will refresh automatically.</span>
+    </span>
+  </div>
+
+  <div class="container">
+    <div class="layout-column-group">
+      <!-- Calculation Assumptions - positioned to be above Expense Mode -->
+      <div class="common-parameters-container collapsible-section">
+        <div class="collapsible-header">
+          <span class="description">Adjust return, inflation, duration & withdrawal timing.</span>
+          <span class="toggle-icon">+</span>
+        </div>
+        <div class="collapsible-content">
+          <div class="slider-container">
+            <label for="r_slider">Expected Annual Return (%):</label>
+            <input type="range" id="r_slider" name="r" min="0" max="15" step="0.1" value="7"> <!-- {{ r_form_val }} -->
+            <input type="text" id="r_output" class="number-input" value="7"> <!-- {{ r_form_val }} -->
+          </div>
+          <div class="slider-container">
+            <label for="i_slider">Expected Annual Inflation (%):</label>
+            <input type="range" id="i_slider" name="i" min="0" max="10" step="0.1" value="3"> <!-- {{ i_form_val }} -->
+            <input type="text" id="i_output" class="number-input" value="3"> <!-- {{ i_form_val }} -->
+          </div>
+          <div class="slider-container">
+            <label for="T_slider">Retirement Duration (years):</label>
+        <input type="range" id="T_slider" name="T" min="10" max="100" step="1" value="30"> <!-- {{ T_form_val }} -->
+            <input type="text" id="T_output" class="number-input" value="30"> <!-- {{ T_form_val }} -->
+          </div>
+          <div class="slider-container">
+            <label>Withdrawal Timing:</label>
+            <input type="radio" name="withdrawal_time" value="start" <!-- {% if withdrawal_time_form_val=='start' %}checked{% endif %} --> > Start of Year
+            <input type="radio" name="withdrawal_time" value="end" <!-- {% if withdrawal_time_form_val=='end' %}checked{% endif %} --> checked> End of Year
+          </div>
+        </div>
+      </div>
+
+      <!-- Left Column: Expense Mode -->
+      <div class="column" id="left_column">
+        <h2>Expense Mode
+          <span class="info-icon">&#9432;
+            <span class="tooltip-text">In Expense Mode, you input your desired annual expenses, and the calculator determines the FIRE number (total portfolio) you'll need.</span>
+          </span>
+        </h2>
+        <div class="slider-container">
+          <label for="W_slider_left">Annual Expenses (W):</label>
+          <input type="range" id="W_slider_left" name="W" min="0" max="1000000" step="1000" value="50000"> <!-- {{ fire_W_input_val }} -->
+          <input type="text" id="W_output_left" class="number-input" value="50,000.00"> <!-- {{ '{:,.2f}'.format(fire_W_input_val) }} -->
+        </div>
+        <div class="result-section">
+          <p><strong>Calculated FIRE Number:</strong> <span id="fire_number_W_display">$1,250,000.00</span></p> <!-- {{ fire_P_calculated_val }} -->
+          <p><strong>Your Annual Expense (Input):</strong> <span id="annual_expense_W_display">$50,000.00</span></p> <!-- ${{ '{:,.2f}'.format(fire_W_input_val) }} -->
+        </div>
+        <h3>Portfolio Balance</h3>
+        <div id="portfolio_plot_W" class="plot-container">
+          <!-- {{ portfolio_plot_fire | safe }} -->
+          <p>Portfolio balance plot will appear here.</p>
+        </div>
+        <h3>Annual Withdrawals</h3>
+        <div id="withdrawal_plot_W" class="plot-container">
+          <!-- {{ withdrawal_plot_fire | safe }} -->
+          <p>Annual withdrawals plot will appear here.</p>
+        </div>
+        <h3>Yearly Data</h3>
+        <div id="table_data_W_container" class="table-container">
+          <!-- Table for W mode will be injected here by JS -->
+          <!-- {{ table_data_fire_html | safe if table_data_fire_html else "<p>Yearly data table will appear here after calculation.</p>" }} -->
+          <p>Yearly data table will appear here after calculation.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="layout-column-group">
+      <!-- Export Button Container - positioned to be above FIRE Mode -->
+      <div class="export-button-container-above-fire">
+        <button class="export-btn" onclick="exportReport()">Export Report</button>
+      </div>
+
+      <!-- Right Column: FIRE Mode -->
+      <div class="column" id="right_column">
+        <h2>FIRE Mode
+          <span class="info-icon">&#9432;
+            <span class="tooltip-text">In FIRE Mode, you input your target FIRE number (total portfolio), and the calculator determines the maximum sustainable annual expense you can withdraw.</span>
+          </span>
+        </h2>
+        <div class="slider-container">
+          <label for="P_slider_right">FIRE Number (P):</label>
+          <input type="range" id="P_slider_right" name="P" min="0" max="25000000" step="1000" value="1000000"> <!-- {{ expense_P_input_val if expense_P_input_val != 'N/A' else 0 }} -->
+          <input type="text" id="P_output_right" class="number-input" value="1,000,000.00"> <!-- {{ '{:,.2f}'.format(expense_P_input_val) if expense_P_input_val != 'N/A' else expense_P_input_val }} -->
+        </div>
+        <div class="result-section">
+          <p><strong>Your FIRE Number (Input):</strong> <span id="fire_number_P_display">$1,000,000.00</span></p> <!-- ${{ '{:,.2f}'.format(expense_P_input_val) if expense_P_input_val != 'N/A' else expense_P_input_val }} -->
+          <p><strong>Max Sustainable Annual Expense:</strong> <span id="annual_expense_P_display">$40,000.00</span></p> <!-- {{ expense_W_calculated_val }} -->
+        </div>
+        <h3>Portfolio Balance</h3>
+        <div id="portfolio_plot_P" class="plot-container">
+          <!-- {{ portfolio_plot_expense | safe }} -->
+          <p>Portfolio balance plot will appear here.</p>
+        </div>
+        <h3>Annual Withdrawals</h3>
+        <div id="withdrawal_plot_P" class="plot-container">
+          <!-- {{ withdrawal_plot_expense | safe }} -->
+          <p>Annual withdrawals plot will appear here.</p>
+        </div>
+        <h3>Yearly Data</h3>
+        <div id="table_data_P_container" class="table-container">
+          <!-- Table for P mode will be injected here by JS -->
+          <!-- {{ table_data_expense_html | safe if table_data_expense_html else "<p>Yearly data table will appear here after calculation.</p>" }} -->
+          <p>Yearly data table will appear here after calculation.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button id="recalculate_button" class="recalculate-btn" style="margin-top: 30px;">Update Results</button> <!-- Changed text -->
+  <a href="/">← Back to Calculator</a>
+
+  <script>
+    // Page-specific JavaScript for result.html (the interactive part)
+    // The toggleTheme and applyTheme functions are now in theme.js
+    function exportReport() {
+      // console.log("exportReport function called"); 
+      window.print();
+    }
+    // The DOMContentLoaded listener should be part of this same script block
+document.addEventListener('DOMContentLoaded', function () {
+    // --- Input Elements ---
+    // Left Column (Expense Mode)
+    const W_slider_left = document.getElementById('W_slider_left');
+    const W_output_left = document.getElementById('W_output_left');
+
+    // Right Column (FIRE Mode)
+    const P_slider_right = document.getElementById('P_slider_right');
+    const P_output_right = document.getElementById('P_output_right');
+
+    // Common Parameters
+    const r_slider = document.getElementById('r_slider');
+    const r_output = document.getElementById('r_output');
+    const i_slider = document.getElementById('i_slider');
+    const i_output = document.getElementById('i_output');
+    const T_slider = document.getElementById('T_slider');
+    const T_output = document.getElementById('T_output');
+    const withdrawal_time_radios = document.querySelectorAll('input[name="withdrawal_time"]');
+
+    // --- Output Display Elements ---
+    const displayFireNumberW = document.getElementById('fire_number_W_display');
+    const displayAnnualExpenseW = document.getElementById('annual_expense_W_display');
+    const divPortfolioPlotW = document.getElementById('portfolio_plot_W');
+    const divWithdrawalPlotW = document.getElementById('withdrawal_plot_W');
+
+    const displayFireNumberP = document.getElementById('fire_number_P_display');
+    const displayAnnualExpenseP = document.getElementById('annual_expense_P_display');
+    const divPortfolioPlotP = document.getElementById('portfolio_plot_P');
+    const divWithdrawalPlotP = document.getElementById('withdrawal_plot_P');
+
+    // Table containers
+    const tableDataWContainer = document.getElementById('table_data_W_container');
+    const tableDataPContainer = document.getElementById('table_data_P_container');
+
+    // --- Recalculate Button ---
+    const recalculateButton = document.getElementById('recalculate_button');
+    if (recalculateButton) {
+        // Pass a specific identifier or the button itself as source for full refresh
+        recalculateButton.addEventListener('click', () => handleInputChange(recalculateButton));
+    }
+
+    // --- Collapsible Section Logic ---
+    const collapsibleHeaders = document.querySelectorAll('.collapsible-header');
+    // console.log("Found collapsible headers:", collapsibleHeaders.length); // Debugging
+    collapsibleHeaders.forEach(header => {
+        header.addEventListener('click', function() {
+            // console.log("Collapsible header clicked:", this); // Debugging
+            const section = this.closest('.collapsible-section');
+            // console.log("Found section:", section); // Debugging
+            if (section) {
+                section.classList.toggle('expanded');
+                // console.log("Toggled 'expanded' class. Section now has 'expanded':", section.classList.contains('expanded')); // Debugging
+                const icon = this.querySelector('.toggle-icon');
+                if (icon) {
+                    icon.textContent = section.classList.contains('expanded') ? '−' : '+'; // Use minus sign for expanded
+                }
+            } else {
+                // console.error("Could not find .collapsible-section parent for header:", this); // Debugging
+            }
+        });
+    });
+    function formatNumber(numStr, precision = 2) {
+        let num = parseFloat(String(numStr).replace(/[^0-9.-]+/g,""));
+        if (isNaN(num)) {
+            // Allow "N/A" to pass through if it's explicitly set
+            return (String(numStr).toUpperCase() === "N/A") ? "N/A" : "0.00";
+        }
+        return num.toLocaleString('en-US', { minimumFractionDigits: precision, maximumFractionDigits: precision, useGrouping: true });
+    }
+
+    function parseFormattedNumber(str) {
+        if (typeof str !== 'string') return parseFloat(str) || 0;
+        return parseFloat(str.replace(/,/g, '')) || 0;
+    }
+
+    // Simplified setupInputListeners as common inputs no longer need to sync with a counterpart
+    function setupInputListeners(slider, output, isPercentOrYears = false) {
+        slider.addEventListener('input', () => {
+            const val = slider.value;
+            output.value = isPercentOrYears ? val : formatNumber(val);
+            handleInputChange(slider); // Pass slider as source
+        });
+        output.addEventListener('change', () => {
+            let val = isPercentOrYears ? parseFloat(output.value) : parseFormattedNumber(output.value);
+            val = Math.max(parseFloat(slider.min), Math.min(parseFloat(slider.max), val));
+            slider.value = val;
+            // Re-format the output field using the slider's actual value (which respects its step)
+            output.value = isPercentOrYears ? slider.value : formatNumber(slider.value);
+            handleInputChange(output); // Pass output field as source
+        });
+    }
+
+    // Setup listeners for unique inputs
+    setupInputListeners(W_slider_left, W_output_left, false);
+    setupInputListeners(P_slider_right, P_output_right, false);
+
+    // Setup listeners for common inputs
+    setupInputListeners(r_slider, r_output, true); // isPercentOrYears = true
+    setupInputListeners(i_slider, i_output, true); // isPercentOrYears = true
+    setupInputListeners(T_slider, T_output, true); // isPercentOrYears = true
+
+    withdrawal_time_radios.forEach(radio => radio.addEventListener('change', () => {
+        handleInputChange(radio); // Pass radio as source
+    }));
+
+
+    function handleInputChange(sourceElement = null) { // Added sourceElement parameter
+        const formData = new FormData();
+        formData.append('W', parseFormattedNumber(W_output_left.value));
+        formData.append('P', parseFormattedNumber(P_output_right.value));
+        // Read from the single common inputs
+        formData.append('r', r_output.value);
+        formData.append('i', i_output.value);
+        formData.append('T', T_output.value);
+        const withdrawal_time_selected = document.querySelector('input[name="withdrawal_time"]:checked');
+        formData.append('withdrawal_time', withdrawal_time_selected ? withdrawal_time_selected.value : 'end');
+
+        fetch('/update', {
+            method: 'POST',
+            body: formData
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (data.error) {
+                console.error('Error from server:', data.error);
+                alert('Error updating calculations: ' + data.error);
+                return;
+            }
+            updatePage(data, sourceElement); // Pass sourceElement to updatePage
+        })
+        .catch(error => {
+            console.error('Error fetching/processing update:', error);
+            alert('Could not update calculations. See console for details.');
+        });
+    }
+
+    /**
+     * Replaces the content of a container with new HTML and ensures any scripts
+     * within the new HTML are executed. This is crucial for Plotly graphs.
+     * @param {HTMLElement} containerElement The DOM element to update.
+     * @param {string} htmlString The new HTML content (e.g., from server).
+     */
+    function updateElementWithScriptExecution(containerElement, htmlString) {
+        containerElement.innerHTML = htmlString; // Set the new HTML
+        // Find script tags within the newly inserted HTML
+        const scripts = Array.from(containerElement.getElementsByTagName("script"));
+        scripts.forEach(oldScript => {
+            const newScript = document.createElement("script");
+            // Copy attributes (like type)
+            Array.from(oldScript.attributes).forEach(attr => newScript.setAttribute(attr.name, attr.value));
+            // Copy the script content
+            newScript.appendChild(document.createTextNode(oldScript.innerHTML));
+            // Replace the old script tag with the new one to encourage execution
+            oldScript.parentNode.replaceChild(newScript, oldScript);
+        });
+    }
+
+    function updateExportCsvLink() {
+      const container = document.getElementById('exportParamsContainer');
+      const exportLink = document.getElementById('exportCsvLink');
+
+      if (container && exportLink) {
+        const params = new URLSearchParams();
+        // Read current values from the input fields or data attributes that are kept up-to-date
+        params.append('W', parseFormattedNumber(W_output_left.value) || container.dataset.w || '0');
+        params.append('r', r_output.value || container.dataset.r || '0');
+        params.append('i', i_output.value || container.dataset.i || '0');
+        params.append('T', T_output.value || container.dataset.t || '0');
+        const withdrawal_time_selected_for_export = document.querySelector('input[name="withdrawal_time"]:checked');
+        params.append('withdrawal_time', (withdrawal_time_selected_for_export ? withdrawal_time_selected_for_export.value : container.dataset.withdrawalTime) || 'end'); // '{{ TIME_END_const }}'
+        // Determine current mode for export. This might need refinement based on which panel was last interacted with or a dedicated mode selector for export.
+        // For simplicity, let's assume it uses the initial mode or a default if not clearly defined.
+        params.append('mode', container.dataset.mode || 'withdrawal'); // '{{ MODE_WITHDRAWAL_const }}'
+        params.append('P', parseFormattedNumber(P_output_right.value) || container.dataset.p || '0');
+        params.append('D', container.dataset.d || '0.0'); // Assuming D is not directly editable on result page, use initial
+        exportLink.href = `/export_csv?${params.toString()}`;
+      }
+    }
+    function updatePage(data, sourceElement = null) { // Added sourceElement parameter
+        // Update Left Column (Expense Mode - W input, P calculated)
+        displayFireNumberW.textContent = data.fire_number_W;
+        displayAnnualExpenseW.textContent = data.annual_expense_W;
+        updateElementWithScriptExecution(divPortfolioPlotW, data.portfolio_plot_W);
+        updateElementWithScriptExecution(divWithdrawalPlotW, data.withdrawal_plot_W);
+
+        // Update Right Column (FIRE Mode - P input, W calculated)
+        displayFireNumberP.textContent = data.fire_number_P;
+        displayAnnualExpenseP.textContent = data.annual_expense_P;
+        updateElementWithScriptExecution(divPortfolioPlotP, data.portfolio_plot_P);
+        updateElementWithScriptExecution(divWithdrawalPlotP, data.withdrawal_plot_P);
+
+        // Update tables if HTML is provided
+        if (data.table_data_W_html && tableDataWContainer) {
+            tableDataWContainer.innerHTML = data.table_data_W_html;
+        }
+        if (data.table_data_P_html && tableDataPContainer) {
+            tableDataPContainer.innerHTML = data.table_data_P_html;
+        }
+
+        // Update the "other" column's primary input based on calculations
+        // Update P_slider_right and P_output_right from calculated P (data.fire_number_W)
+        // Only update if P_output_right (or its slider) was not the direct source of this change event.
+        if (sourceElement !== P_output_right && sourceElement !== P_slider_right) {
+            if (data.fire_number_W !== "N/A") {
+                let numeric_P = parseFormattedNumber(data.fire_number_W.replace('$', ''));
+                P_slider_right.value = Math.min(parseFloat(P_slider_right.max), Math.max(parseFloat(P_slider_right.min), numeric_P));
+                P_output_right.value = formatNumber(numeric_P);
+            } else {
+                P_output_right.value = "N/A";
+                P_slider_right.value = P_slider_right.min;
+            }
+        }
+
+        // Update W_slider_left and W_output_left from calculated W (data.annual_expense_P)
+        // Only update if W_output_left (or its slider) was not the direct source of this change event.
+        if (sourceElement !== W_output_left && sourceElement !== W_slider_left) {
+            if (data.annual_expense_P !== "N/A") {
+                let numeric_W = parseFormattedNumber(data.annual_expense_P.replace('$', ''));
+                W_slider_left.value = Math.min(parseFloat(W_slider_left.max), Math.max(parseFloat(W_slider_left.min), numeric_W));
+                W_output_left.value = formatNumber(numeric_W);
+            } else {
+                W_output_left.value = "N/A";
+                W_slider_left.value = W_slider_left.min;
+            }
+        }
+        // Update the CSV export link with the new values
+        updateExportCsvLink(); 
+    }
+
+    function initializeFormValues() {
+        // Ensure initial text inputs are formatted and sliders match
+        W_output_left.value = formatNumber(W_slider_left.value);
+
+        // For P_output_right, only re-format if its current server-rendered value isn't "N/A"
+        // Otherwise, the Django template has already set it to "N/A" correctly.
+        if (P_output_right.value.toUpperCase() !== "N/A") {
+            P_output_right.value = formatNumber(P_slider_right.value);
+        }
+        
+        // For common r, i, T, values are direct from their sliders
+        r_output.value = r_slider.value;
+        i_output.value = i_slider.value;
+        T_output.value = T_slider.value;
+    }
+
+    initializeFormValues();
+    // The page is already rendered with initial plots by the server.
+    // No initial handleInputChange() call is strictly needed unless client-side formatting
+    // significantly changes values that would lead to different initial plots.
+    // The main goal is to make *changes* interactive.
+    updateExportCsvLink(); // Initialize the export link on page load
+});
+
+</script>
+</body>
+</html>

--- a/docs/settings.html
+++ b/docs/settings.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>FIRE Calculator Settings</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="static/css/main.css">
+  <script>
+    function saveSettings() {
+      const theme = document.getElementById("themeSelect").value;
+      const fontSize = document.getElementById("fontSize").value;
+      const panelOpacity = document.getElementById("panelOpacity").value;
+      // Save the binary theme preference
+      localStorage.setItem('theme', theme); 
+      // Save other settings
+      const settings = { fontSize, panelOpacity }; // Theme is now separate
+      localStorage.setItem("fireSettings", JSON.stringify(settings));
+      applySettings(); // Apply all settings including the new theme state
+      alert("Settings saved!");
+    }
+    
+    function applySettings() {
+      // Call the global applyTheme from theme.js
+      if (typeof applyTheme === "function") {
+        applyTheme(); 
+      }
+
+      // Apply font size and panel opacity specifically
+      const fireSettingsSaved = localStorage.getItem("fireSettings");
+      if (fireSettingsSaved) {
+        const settings = JSON.parse(fireSettingsSaved);
+        if (settings.fontSize) {
+          document.documentElement.style.setProperty("--font-size", settings.fontSize + "px");
+          document.body.style.fontSize = settings.fontSize + "px"; // Directly set body font size
+        }
+        if (settings.panelOpacity) {
+          // Assumes --panel-alpha is defined in main.css
+          document.documentElement.style.setProperty("--panel-alpha", settings.panelOpacity);
+        }
+      }
+    }
+    // Ensure global applyTheme (if defined) and then page-specific applySettings are called
+    document.addEventListener("DOMContentLoaded", function() {
+        if (typeof applyTheme === "function") { // From theme.js
+            applyTheme();
+        }
+        applySettings(); // Page-specific settings
+
+        // Initialize form controls with saved values
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+            document.getElementById("themeSelect").value = savedTheme;
+        }
+
+        const fireSettingsSaved = localStorage.getItem("fireSettings");
+        if (fireSettingsSaved) {
+            const settings = JSON.parse(fireSettingsSaved);
+            if (settings.fontSize) {
+                document.getElementById("fontSize").value = settings.fontSize;
+            }
+            if (settings.panelOpacity) {
+                document.getElementById("panelOpacity").value = settings.panelOpacity;
+            }
+            // If panelOpacity is not in fireSettings, it will retain its default or CSS-set value.
+        }
+    });
+  </script>
+</head>
+<body>
+  <script src="static/js/theme.js"></script>
+  <!-- applyTheme() is called by DOMContentLoaded above -->
+
+  <header> <!-- Added a simple header for consistency -->
+    <div>Settings</div>
+    <div class="header-right">
+        <button class="theme-toggle" onclick="toggleTheme()">Toggle Theme</button>
+        <a href="/" class="settings-link" style="font-size: 1.5em;">&times;</a> <!-- Close icon -->
+    </div>
+  </header>
+
+  <div class="container settings-page">
+    <h2>Settings</h2>
+    <label for="themeSelect">Select Theme:</label>
+    <select id="themeSelect">
+      <option value="light">Light Default</option>
+      <option value="dark">Dark Default</option>
+      <!-- Keep other theme options if you plan to expand main.css for them -->
+      <!-- <option value="Pastel">Pastel</option> -->
+      <!-- <option value="Minimal">Minimal</option> -->
+    </select>
+    
+    <label for="fontSize">Font Size (px):</label>
+    <input type="number" id="fontSize" value="16" min="12" max="24">
+    <small>Changes the base font size across the application (Default: 16px).</small>
+    
+    <label for="panelOpacity">Panel Opacity (0-1):</label>
+    <input type="range" id="panelOpacity" min="0.5" max="1" step="0.01" value="0.7">
+    <small>Adjusts the transparency of UI panels (Default: 0.7 for light, 0.9 for dark).</small>
+    
+    <button onclick="saveSettings()">Save Settings</button>
+    <p><small>Settings are saved in your browser's local storage.</small></p>
+    <a href="/">← Back to Calculator</a>
+  </div>
+</body>
+</html>

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -1,0 +1,659 @@
+/* static/css/main.css */
+:root {
+  --bg-light: #fefefe;
+  --bg-accent: #A8E6CF;
+  --bg-secondary: #FFD3B6;
+  --text-light: #333;
+  --panel-rgb: 255, 255, 255; /* Light theme panel RGB */
+  --panel-alpha: 0.7;       /* Default panel alpha */
+  --panel-bg: rgba(var(--panel-rgb), var(--panel-alpha));
+  --input-range-bg: rgba(255,255,255,0.4);
+  --thumb-bg: #fff;
+  --thumb-border: #A8E6CF;
+  --font-size: 16px; /* Default font size */
+}
+
+body.dark {
+  --bg-light: #1E1E1E;
+  /* Dark theme gradient colors */
+  --bg-accent: #2E3C40; /* Dark Slate / Deep Teal */
+  --bg-secondary: #1A2930; /* Very Dark Blue / Almost Black Blue */
+  --text-light: #e0e0e0;
+  --panel-rgb: 30, 30, 30;   /* Dark theme panel RGB */
+  --panel-alpha: 0.9;       /* Default dark theme panel alpha */
+  --panel-bg: rgba(var(--panel-rgb), var(--panel-alpha));
+  --input-range-bg: rgba(255,255,255,0.2);
+  --thumb-bg: #e0e0e0;
+  --thumb-border: #80CBC4;
+}
+
+body {
+  font-family: 'Roboto', sans-serif;
+  font-size: var(--font-size); /* Apply global font size */
+  margin: 0;
+  padding: 0;
+  background: linear-gradient(135deg, var(--bg-accent) 0%, var(--bg-secondary) 100%);
+  color: var(--text-light);
+  overflow-x: hidden;
+  transition: background 0.5s, color 0.5s;
+}
+
+header {
+  background: var(--panel-bg);
+  backdrop-filter: blur(10px);
+  color: var(--text-light);
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 26px;
+  font-weight: 500;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: background 0.5s, color 0.5s;
+  position: relative;
+}
+
+body.dark header { /* Ensure header uses the dark panel background */
+  background: var(--panel-bg);
+  color: #e0e0e0;
+}
+
+.header-right {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.theme-toggle {
+  cursor: pointer;
+  font-size: 16px;
+  background: transparent;
+  border: none;
+  color: var(--text-light);
+}
+
+body.dark .theme-toggle {
+  color: #e0e0e0;
+}
+
+.settings-link {
+  text-decoration: none;
+  font-size: 24px;
+  color: var(--text-light);
+}
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 30px auto;
+  width: 90%;
+  justify-content: space-around;
+}
+
+/* Styles for settings.html and index.html containers */
+.container.settings-page, .container.index-page {
+  max-width: 700px; /* Adjusted max-width for these pages */
+  background: var(--panel-bg);
+  border-radius: 16px;
+  padding: 20px;
+  /* Ensure single column layout for form content */
+  display: flex; 
+  flex-direction: column;
+  align-items: stretch; /* Make children take full width */
+  margin: 30px auto; /* Ensure centering */
+  box-shadow: 0 8px 32px rgba(31,38,135,0.2);
+  backdrop-filter: blur(8px);
+  transition: background 0.5s;
+}
+body.dark .container.settings-page, body.dark .container.index-page {
+  background: rgba(43, 43, 43, 0.85); /* #2b2b2b with opacity */
+}
+
+
+.column { /* For result.html */
+  flex: 1;
+  min-width: 320px;
+  max-width: 480px;
+  margin: 20px;
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--panel-bg);
+  box-shadow: 0 8px 32px rgba(31,38,135,0.2);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255,255,255,0.18);
+}
+
+.slider-container { /* For result.html */
+  margin: 15px 0;
+}
+
+label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 6px;
+  color: var(--text-light);
+}
+
+.number-input { /* For result.html */
+  width: 100%;
+  padding: 6px;
+  font-size: 16px;
+  font-weight: 500;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  text-align: right;
+  margin-top: 4px;
+}
+
+input[type=range] {
+  width: 100%;
+  margin: 8px 0;
+  -webkit-appearance: none;
+  background: var(--input-range-bg);
+  height: 6px;
+  border-radius: 3px;
+}
+
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  background: var(--thumb-bg);
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid var(--thumb-border);
+  margin-top: -7px;
+}
+
+.result-section { /* For result.html */
+  margin-top: 20px;
+  padding: 15px;
+  background: rgba(255,255,255,0.25);
+  border-radius: 10px;
+  color: var(--text-light);
+}
+
+a {
+  display: block;
+  margin: 20px auto;
+  text-align: center;
+  text-decoration: none;
+  color: var(--text-light);
+  font-weight: 500;
+  width: 200px;
+  padding: 10px;
+  background: var(--panel-bg);
+  border-radius: 30px;
+  transition: background 0.3s;
+}
+
+a:hover {
+  background: rgba(255,255,255,0.9);
+}
+body.dark a:hover {
+    background: rgba(70, 70, 70, 0.9);
+}
+
+
+.recalculate-btn {
+  display: block;
+  margin: 20px auto; /* Centered with some margin */
+  padding: 12px 25px;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--text-light);
+  background-color: var(--panel-bg);
+  border: 1px solid var(--thumb-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.3s, box-shadow 0.3s;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.recalculate-btn:hover {
+  background-color: #A8E6CF; /* Light theme accent for hover */
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+body.dark .recalculate-btn {
+  background-color: #37474F; /* Darker button bg */
+  border-color: var(--thumb-border);
+  color: var(--text-light);
+}
+
+body.dark .recalculate-btn:hover {
+  background-color: #4DB6AC;
+}
+
+.common-parameters-container {
+  /* Will behave like a column item now */
+  flex: 1;
+  min-width: 320px; /* Consistent with columns */
+  max-width: 480px; /* Consistent with columns */
+  margin: 20px;     /* Consistent with columns */
+  border-radius: 16px; /* Consistent with columns */
+  font-size: 0.85em;
+  border: 1px solid transparent; /* Placeholder for border on expand */
+  transition: background-color 0.3s, border-color 0.3s, box-shadow 0.3s;
+}
+
+.common-parameters-container.expanded { /* Styles for the main container when expanded */
+  background: var(--panel-bg);
+  box-shadow: 0 8px 32px rgba(31,38,135,0.2);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255,255,255,0.18);
+}
+
+.collapsible-header {
+  /* Styling to match .export-btn */
+  font-size: 15px; /* Matches .export-btn */
+  font-weight: 500; /* Less bold */
+  color: var(--text-light);
+  background-color: var(--panel-bg);
+  border: 1px solid var(--thumb-border);
+  border-radius: 8px;
+  padding: 10px 15px; /* Adjusted padding slightly for description + icon */
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: background-color 0.3s; /* For hover effect if added */
+}
+
+.collapsible-header:hover {
+    background-color: #A8E6CF; /* Light theme accent */
+}
+
+body.dark .collapsible-header:hover {
+    background-color: #4DB6AC; /* Dark theme accent for hover */
+}
+
+.collapsible-header .toggle-icon {
+  font-weight: bold;
+  font-size: 1.1em;
+}
+
+.collapsible-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease-out, padding 0.3s ease-out;
+  padding: 0 15px; /* Horizontal padding, vertical padding comes with max-height */
+}
+
+.common-parameters-container.expanded .collapsible-content {
+  max-height: 350px;
+  padding: 10px 15px; /* Add vertical padding when expanded */
+}
+
+.collapsible-header .description {
+  /* Description is now the main text of the header, so it inherits header styles */
+  flex-grow: 1; /* Allow description to take available space */
+  margin-right: 10px; /* Space before the toggle icon */
+  font-weight: 500; /* Match button text weight */
+}
+
+/* Keep existing styles for .slider-container, label, .number-input */
+.common-parameters-container .slider-container {
+  margin-bottom: 8px; /* Tighter spacing between sliders */
+}
+
+.export-btn {
+  padding: 10px 20px;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-light);
+  background-color: var(--panel-bg);
+  border: 1px solid var(--thumb-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.3s, box-shadow 0.3s;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.export-btn:hover { /* Light theme hover */
+  background-color: #A8E6CF;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+body.dark .export-btn {
+  background-color: #37474F; /* Darker button bg */
+  border-color: var(--thumb-border);
+  color: var(--text-light);
+}
+
+body.dark .export-btn:hover {
+  background-color: #4DB6AC; /* Dark theme accent for hover */
+}
+
+.layout-column-group {
+  flex: 1 1 480px; /* Allow shrinking, prefer 480px basis */
+  min-width: 320px; /* Min width of a group */
+  max-width: 500px; /* Max width of a group, allowing some padding/margin */
+  margin: 10px;     /* Margin for the group itself */
+  display: flex;
+  flex-direction: column;
+}
+
+.export-button-container-above-fire {
+  /* Behaves like a column item */
+  flex: 1;
+  min-width: 320px;
+  max-width: 480px;
+  margin: 20px;
+  display: flex;
+  justify-content: center; /* Center the button within this container */
+  align-items: flex-start; /* Align button to the top */
+}
+
+/* Adjust margins for items when they are direct children of a layout-column-group */
+.layout-column-group > .common-parameters-container,
+.layout-column-group > .export-button-container-above-fire,
+.layout-column-group > .column {
+  margin: 10px 0; /* Vertical spacing, horizontal handled by item's own width/max-width and group's alignment */
+  width: 100%; /* Make items take full width of their group, respecting their own max-width */
+}
+
+.info-icon {
+  display: inline-block;
+  margin-left: 8px;
+  color: var(--thumb-border);
+  cursor: help;
+  position: relative;
+  font-weight: bold;
+}
+
+.info-icon .tooltip-text {
+  visibility: hidden;
+  width: 220px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 8px;
+  position: absolute;
+  z-index: 10;
+  bottom: 135%; /* Position above the icon */
+  left: 50%;
+  margin-left: -110px; /* Use half of the width to center */
+  opacity: 0;
+  transition: opacity 0.3s;
+  font-size: 0.9em;
+  font-weight: normal;
+}
+
+.table-container { /* Hide tables by default on screen */
+  display: none;
+}
+
+.info-icon:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Styles from index.html */
+.form-group {
+  margin: 15px 0;
+}
+input[type="number"] { /* General number input, might need more specific selectors if conflicts */
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+input[type="submit"] {
+  width: 100%;
+  padding: 12px;
+  background: var(--bg-accent);
+  border: none;
+  color: var(--text-light);
+  font-size: 18px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-top: 20px;
+  transition: background 0.3s;
+}
+input[type="submit"]:hover {
+  background: #8fd9b6; /* Consider using a CSS variable for hover */
+}
+body.dark input[type="submit"] {
+    background: var(--thumb-border); /* Example dark theme submit button */
+}
+body.dark input[type="submit"]:hover {
+    background: #4DB6AC;
+}
+
+/* Styles from settings.html */
+.container.settings-page h2 {
+  text-align: center;
+}
+.container.settings-page select,
+.container.settings-page input[type="range"],
+.container.settings-page input[type="number"] {
+  width: 100%;
+  margin-bottom: 12px;
+  box-sizing: border-box; /* Ensure padding/border doesn't expand width */
+}
+.container.settings-page button { /* Save settings button */
+  padding: 10px 20px;
+  background: var(--bg-accent);
+  border: none;
+  color: var(--text-light);
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 16px;
+}
+body.dark .container.settings-page button {
+    background: var(--thumb-border);
+}
+body.dark .container.settings-page button:hover {
+    background: #4DB6AC;
+}
+
+
+/* Styles from compare.html */
+.container.compare-page {
+    /* Override general container flex behavior for this page */
+    display: flex; 
+    flex-direction: column;
+    align-items: stretch; /* Make children take full width */
+    margin: 30px auto; /* Ensure centering */
+    max-width: 900px;
+}
+body.dark .container.compare-page {
+  background: rgba(43, 43, 43, 0.85);
+}
+.scenario-header {
+  margin-bottom: 20px;
+  text-align: center;
+}
+.scenario-header label {
+  margin-right: 10px;
+}
+.scenario-container {
+  display: flex;
+  flex-wrap: nowrap; /* Allows horizontal scrolling if too many scenarios */
+  gap: 10px;
+  margin-bottom: 20px;
+  overflow-x: auto; /* Enable horizontal scroll for scenarios */
+}
+.scenario {
+  flex: 1 0 200px; /* Flex basis of 200px, can grow and shrink */
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 10px;
+  background: #fff; /* Scenarios have their own background */
+  min-width: 200px; /* Min width for a scenario box */
+  cursor: move;
+}
+body.dark .scenario {
+    background: #3a3a3a;
+    border-color: #555;
+}
+.scenario h3 {
+  margin-top: 0;
+  font-size: 16px;
+}
+.compare-page .form-group { /* Specific to compare page form groups */
+  margin: 8px 0;
+}
+.compare-page label {
+  margin-bottom: 4px;
+}
+.compare-page input[type="number"], /* Specific to compare page inputs */
+.compare-page input[type="range"] {
+  width: 100%;
+  box-sizing: border-box;
+}
+.compare-page input[type="number"] {
+  padding: 6px;
+  margin-bottom: 6px;
+}
+.compare-page input[type="range"] {
+  margin-bottom: 4px;
+}
+.compare-page input[type="radio"] {
+  margin-right: 5px;
+}
+.compare-page input[type="submit"] { /* Compare scenarios button */
+  width: 100%;
+  padding: 12px;
+  background: var(--bg-accent);
+  border: none;
+  color: var(--text-light);
+  font-size: 18px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-top: 20px;
+  transition: background 0.3s;
+}
+.compare-page input[type="submit"]:hover {
+  background: #8fd9b6;
+}
+body.dark .compare-page input[type="submit"] {
+    background: var(--thumb-border);
+}
+body.dark .compare-page input[type="submit"]:hover {
+    background: #4DB6AC;
+}
+.compare-page table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+.compare-page th, .compare-page td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: center;
+}
+.compare-page th {
+  background: var(--bg-accent);
+  color: var(--text-light);
+}
+body.dark .compare-page th {
+    background: var(--thumb-border);
+}
+body.dark .compare-page td {
+    border-color: #555;
+}
+
+
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  /* Mobile Responsiveness Fixes for index.html radio buttons */
+  .index-page .radio-group label[for="start"],
+  .index-page .radio-group label[for="end"] {
+    display: block; /* Stack the labels */
+    margin-left: 0; /* Reset any left margin */
+    margin-top: 5px; /* Space above label when stacked */
+    margin-bottom: 10px; /* Space below this radio/label pair */
+  }
+
+  .index-page .radio-group input[type="radio"] {
+    /* Ensure radio buttons align well when labels stack */
+    vertical-align: middle; /* Or adjust as needed */
+    margin-right: 5px; 
+  }
+}
+
+@media (max-width: 480px) { /* From index.html and settings.html */
+  input[type="range"] { /* General, might need more specificity */
+    height: 12px;
+  }
+  /* General button/submit styling for small screens */
+  button, input[type="submit"], .export-btn, .recalculate-btn, .collapsible-header {
+    padding: 14px 24px;
+    font-size: 18px;
+  }
+  .container.settings-page select,
+  .container.settings-page input[type="range"],
+  .container.settings-page input[type="number"] {
+    font-size: 18px; /* From settings.html */
+  }
+}
+
+
+/* Print Styles */
+@media print {
+  body {
+    background: #fff !important; /* Ensure white background for print */
+    color: #000 !important; /* Ensure black text for print */
+    font-size: 10pt;
+    margin: 0; /* Remove default body margins for print */
+    padding: 0;
+    -webkit-print-color-adjust: exact !important; /* Ensure background colors and images print if needed, though we aim for white bg */
+    color-adjust: exact !important;
+    orphans: 3; /* Minimum lines at the bottom of a page before a break */
+    widows: 3;  /* Minimum lines at the top of a page after a break */
+  }
+  header,
+  .export-btn,
+  .recalculate-btn,
+  a[href="/"],
+  .common-parameters-container,
+  .theme-toggle,
+  .settings-link,
+  .info-icon.global-info,
+  div[style*="text-align: center; margin: 15px 0;"]
+   {
+    display: none !important;
+  }
+  .column {
+    box-shadow: none !important;
+    border: 1px solid #ccc !important;
+    margin: 10px 0 !important;
+    padding: 15px !important;
+    width: 95% !important; /* Make columns take more width in print */
+    margin-top: 0 !important; /* Ensure columns start near top of page */
+    page-break-inside: avoid; /* Try to keep individual column content from splitting across pages */
+  }
+  .layout-column-group {
+    margin: 0 !important; /* Remove margin from the groups themselves */
+    padding: 0 !important;
+    page-break-inside: avoid; /* Try to keep groups from splitting if possible */
+  }
+  .container { /* The main container holding the columns */
+      margin-top: 0 !important;
+      padding-top: 0 !important;
+      display: block !important; /* Force block display for print to simplify flow */
+  }
+  .slider-container { display: none !important; } /* Hide all input sliders */
+  .result-section, .plot-container, .table-container { margin-top: 10px; }
+  h2, h3 { font-size: 14pt; margin-bottom: 5px; }
+  .js-plotly-plot .plotly, .js-plotly-plot {
+      max-width: 100% !important;
+      height: auto !important;
+  }
+  table { width: 100%; border-collapse: collapse; margin-top: 10px; font-size: 9pt;}
+  .table-container { /* Make tables visible for print */
+      display: block !important;
+  }
+  th, td { border: 1px solid #ddd; padding: 4px; text-align: left; }
+  th { background-color: #f2f2f2; }
+}

--- a/docs/static/js/theme.js
+++ b/docs/static/js/theme.js
@@ -1,0 +1,42 @@
+// static/js/theme.js
+function toggleTheme() {
+  document.body.classList.toggle('dark');
+  localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+}
+
+function applyTheme() {
+  const storedTheme = localStorage.getItem('theme');
+  const fireSettings = JSON.parse(localStorage.getItem("fireSettings")); // For settings page compatibility
+
+  if (storedTheme === 'dark') {
+    document.body.classList.add('dark');
+  } else if (storedTheme === 'light') {
+    document.body.classList.remove('dark');
+  } else if (fireSettings && fireSettings.theme === "Modern Dark") { // Compatibility with old settings.html
+    document.body.classList.add('dark');
+    localStorage.setItem('theme', 'dark'); // Migrate to new theme key
+  } else {
+    document.body.classList.remove('dark'); // Default to light
+  }
+
+  // Apply font size and panel opacity from fireSettings if they exist
+  if (fireSettings) {
+    if (fireSettings.fontSize) {
+      document.documentElement.style.setProperty("--font-size", fireSettings.fontSize + "px");
+      // Also update body font-size directly if not using --font-size variable globally
+      // This ensures font size is applied even if the --font-size CSS variable is not used everywhere.
+      document.body.style.fontSize = fireSettings.fontSize + "px";
+    }
+    // Note on panelOpacity:
+    // The `panelOpacity` setting from `fireSettings` is applied in `settings.html`'s own
+    // `applySettings()` function by setting the `--panel-alpha` CSS variable.
+    // This `applyTheme()` function (in theme.js) currently does not directly apply panelOpacity,
+    // but it's called by settings.html's `applySettings` to handle the base theme and font size.
+    // If panelOpacity needed to be applied globally by theme.js without settings.html's intervention,
+    // logic to set `--panel-alpha` would be needed here.
+    if (fireSettings.panelOpacity) {
+      // Example of how it could be applied here if needed:
+      // document.documentElement.style.setProperty("--panel-alpha", fireSettings.panelOpacity);
+    }
+  }
+}


### PR DESCRIPTION
- Add a /docs directory.
- Copy HTML templates (index, result, compare, settings) to /docs, adapting them for static serving by:
  - Changing static asset paths (CSS, JS) to relative paths.
  - Removing or commenting out Flask-specific Jinja2 templating.
- Copy static assets (CSS, JS) to /docs/static/.

This change prepares the frontend assets to be served as a static site from the /docs directory, suitable for GitHub Pages deployment. The original Flask application remains unchanged and functional.