### PR TITLE
feat: Implement varying rates of return and inflation over periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Interactive FIRE Calculator built with Flask, Plotly, and jQuery. Features dynam
     *   Consider user accounts if server-side persistence is implemented, allowing users to save and retrieve their data across devices.
 *   **Export Options:**
     *   Implement functionality to export calculation results, tables, and graphs (e.g., as CSV, PDF, or image files).
+*   **Varying Rates of Return/Inflation:**
+    *   Users can specify different rates of return and inflation for different time periods within their simulation.
+    *   The input forms (main calculator and compare scenarios) allow for up to 3 distinct periods, each with its own duration, return rate (%), and inflation rate (%).
+    *   If no specific period data is entered, the calculator will use the "Overall" (Fallback) values for return rate, inflation rate, and total duration.
+    *   The total duration for the simulation is automatically calculated from the sum of individual period durations if periods are specified.
 
 **UI/UX Improvements (incorporating user feedback):**
 *   **Comprehensive UI Review:**

--- a/project/financial_calcs.py
+++ b/project/financial_calcs.py
@@ -2,294 +2,279 @@ import numpy as np
 from flask import current_app
 from .constants import TIME_START, TIME_END # TIME_END will be used by annual_simulation
 
-def annual_simulation(PV, r, i, W, T, withdrawal_time):
+def annual_simulation(PV, W_initial, withdrawal_time, rates_periods):
     """
-    Simulate the annual portfolio balance over T years.
+    Simulate the annual portfolio balance over T years with varying rates.
 
     Args:
         PV (float): Present Value (initial portfolio balance).
-        r (float): Annual rate of return (e.g., 0.05 for 5%).
-        i (float): Annual inflation rate (e.g., 0.02 for 2%).
-        W (float): Initial annual withdrawal amount.
-        T (int): Time horizon in years.
+        W_initial (float): Initial annual withdrawal amount for the first year.
         withdrawal_time (str): Time of withdrawal, "start" or "end" of the year.
+        rates_periods (list of dicts): List of rate periods, e.g.,
+                                       [{'duration': D_years, 'r': R_decimal, 'i': I_decimal}, ...]
 
     Returns:
         tuple: (years_array, balances_list, withdrawals_list)
     """
-    years = np.arange(0, T + 1)
-    balances = []
-    withdrawals = []
-    B = PV
-    for t in range(T):
-        annual_withdrawal = W * ((1 + i) ** t)
-        withdrawals.append(annual_withdrawal)
-        if withdrawal_time == TIME_START: # TIME_START from constants
-            B = B - annual_withdrawal
-            balances.append(B)
-            B = B * (1 + r)
-        else: # Assumes TIME_END if not TIME_START
-            balances.append(B)
-            B = B * (1 + r) - annual_withdrawal
-    balances.append(B)
-    return years, balances, withdrawals
+    if not rates_periods:
+        raise ValueError("rates_periods list cannot be empty.")
 
-def simulate_final_balance(PV, r, i, W, T, withdrawal_time, desired_final_value=0.0):
+    total_T = sum(p.get('duration', 0) for p in rates_periods)
+    if total_T <= 0:
+        raise ValueError("Total duration from rates_periods must be greater than zero.")
+
+    years = np.arange(0, total_T + 1)
+    balances = []
+    sim_withdrawals = [] # Renamed to avoid conflict with outer scope 'withdrawals' in some contexts
+    
+    B = PV
+    current_annual_withdrawal = W_initial
+    
+    current_period_idx = 0
+    time_in_current_period = 0
+    
+    for t_year_idx in range(total_T):
+        # Determine current period's rates
+        while time_in_current_period >= rates_periods[current_period_idx]['duration']:
+            time_in_current_period -= rates_periods[current_period_idx]['duration']
+            current_period_idx += 1
+            if current_period_idx >= len(rates_periods):
+                 # This should not happen if total_T is calculated correctly and loop runs for total_T years
+                raise IndexError("Ran out of rate periods unexpectedly.")
+
+        r_current_period = rates_periods[current_period_idx]['r']
+        i_current_period = rates_periods[current_period_idx]['i']
+
+        # Store the withdrawal for the current year t_year_idx
+        sim_withdrawals.append(current_annual_withdrawal)
+
+        if withdrawal_time == TIME_START:
+            B -= current_annual_withdrawal
+            balances.append(B) # Balance after withdrawal, before growth
+            B *= (1 + r_current_period)
+        else: # TIME_END
+            balances.append(B) # Balance before withdrawal and growth for this year
+            B *= (1 + r_current_period)
+            B -= current_annual_withdrawal
+        
+        # Inflate withdrawal for the *next* year using the current year's inflation
+        current_annual_withdrawal *= (1 + i_current_period)
+        time_in_current_period += 1
+
+    balances.append(B) # Final balance after T years
+    return years, balances, sim_withdrawals
+
+
+def simulate_final_balance(PV, W_initial, withdrawal_time, rates_periods, desired_final_value=0.0):
     """
     Helper function to get the difference between the final balance after T years 
-    and the desired_final_value.
+    (with varying rates) and the desired_final_value.
 
     Args:
         PV (float): Present Value.
-        r (float): Annual rate of return.
-        i (float): Annual inflation rate.
-        W (float): Initial annual withdrawal.
-        T (int): Time horizon in years.
+        W_initial (float): Initial annual withdrawal.
         withdrawal_time (str): "start" or "end".
-        desired_final_value (float, optional): The desired portfolio value at the end of T years. Defaults to 0.0.
-
-    Returns:
-        float: Difference between the final portfolio balance and the desired_final_value.
+        rates_periods (list of dicts): See annual_simulation docstring for structure.
+        desired_final_value (float, optional): Target value. Defaults to 0.0.
     """
-    _, balances, _ = annual_simulation(PV, r, i, W, T, withdrawal_time) # annual_simulation remains unchanged
+    if not rates_periods: # Basic check, annual_simulation will also raise
+        raise ValueError("rates_periods list cannot be empty for simulation.")
+        
+    _, balances, _ = annual_simulation(PV, W_initial, withdrawal_time, rates_periods)
     actual_final_balance = balances[-1]
     return actual_final_balance - desired_final_value
 
-def find_required_portfolio(W, r, i, T, withdrawal_time, desired_final_value=0.0):
+def find_required_portfolio(W_initial, withdrawal_time, rates_periods, desired_final_value=0.0):
     """
-    Find the required initial portfolio (PV) to sustain withdrawals W for T years,
-    aiming for a specific desired_final_value. Uses a bisection method.
+    Find the required initial portfolio (PV) to sustain withdrawals W_initial (with inflation)
+    for the duration specified in rates_periods, aiming for a specific desired_final_value.
+    Uses a bisection method.
 
     Args:
-        W (float): Initial annual withdrawal.
-        r (float): Annual rate of return.
-        i (float): Annual inflation rate.
-        T (int): Time horizon in years.
+        W_initial (float): Initial annual withdrawal.
         withdrawal_time (str): "start" or "end".
-        desired_final_value (float, optional): The desired portfolio value at the end of T years. Defaults to 0.0.
-
-    Returns:
-        float: Required initial portfolio.
+        rates_periods (list of dicts): List of rate periods, e.g.,
+                                       [{'duration': D_years, 'r': R_decimal, 'i': I_decimal}, ...].
+        desired_final_value (float, optional): Target value. Defaults to 0.0.
     """
-    # Calculate Present Value of withdrawals
-    if T == 0:
-        pv_withdrawals = 0.0
-    elif r != i:
-        # Handle r = i = -1 case for (1+i) in denominator if needed, though r validation r >= -0.5
-        # For (1+i)/(1+r), if r = -1, (1+r) is 0. This is problematic.
-        # Current r validation (-0.5 to 1.0) means 1+r is always >= 0.5.
-        # If i = -1, 1+i is 0. If r = -1, (r-i) could be non-zero.
-        # If r = i, the other formula is used.
-        # If r != i:
-        #   If 1+r is 0 (r=-1), this is an issue. current_app.config['R_VALID_MIN'] = -0.5
-        #   If r-i is 0, this is r=i, handled by else.
-        pv_withdrawals = (W / (r - i)) * (1 - ((1 + i) / (1 + r))**T)
-    else: # r == i
-        if (1 + i) == 0: # Handles r = i = -1. PV of withdrawals is infinite if W > 0.
-            pv_withdrawals = float('inf') if W > 0 else 0.0
-        else:
-            pv_withdrawals = W * T / (1 + i)
-
-    # Calculate Present Value of the desired final target
-    if T == 0:
-        pv_of_final_target = desired_final_value
-    elif (1 + r) <= 0: # r <= -1. Given r >= -0.5, this path shouldn't be hit with valid r.
-                       # If it were possible, and desired_final_value > 0, it's effectively inf.
-        pv_of_final_target = float('inf') if desired_final_value > 0 else 0.0
-    else: # 1+r > 0
-        pv_of_final_target = desired_final_value / ((1 + r) ** T)
-
-    if pv_withdrawals == float('inf') or pv_of_final_target == float('inf'):
-        lower = float('inf')
-    else:
-        lower = pv_withdrawals + pv_of_final_target
+    if not rates_periods:
+        raise ValueError("rates_periods list cannot be empty.")
     
-    if withdrawal_time == TIME_START and T > 0: # TIME_START from constants
-        # This adjustment should apply to the total PV needed.
-        # (1+r) is guaranteed to be > 0 due to r >= -0.5 validation.
-        if lower != float('inf'): # Avoid inf * factor
-             lower *= (1 + r) 
-        
-    upper = lower * 1.5 if lower > 0 else (max(desired_final_value, W) * 1.5 if max(desired_final_value, W) > 0 else 1.0) 
-    if lower == float('inf'): # If lower bound is already infinite
-        return float('inf')
-    if upper == float('inf') and lower == float('inf'): # if lower was inf, upper became inf
-        return float('inf')
-    if W == 0 and desired_final_value == 0: # If no withdrawals and no target, PV is 0
+    total_T_from_periods = sum(p.get('duration', 0) for p in rates_periods)
+
+    if total_T_from_periods == 0:
+        return desired_final_value # No time for withdrawals or growth/loss
+
+    if W_initial == 0 and desired_final_value == 0:
         return 0.0
-    if T == 0: # If T=0, required PV is just the desired_final_value (no time for withdrawals or growth)
-        return desired_final_value
 
-
-    # We want (actual_final_balance - desired_final_value) >= 0.
-    # So, loop while simulate_final_balance(...) < 0.
-    iteration_count = 0
-    max_iterations = 100 # Safety break for the while loop finding upper bound
-
-    # Ensure upper is sufficiently large to make simulate_final_balance non-negative
-    # or until PV_MAX_GUESS_LIMIT is hit.
-    while simulate_final_balance(upper, r, i, W, T, withdrawal_time, desired_final_value) < 0:
-        iteration_count += 1
-        if iteration_count > max_iterations: # Prevent infinite loop
-             # This implies that even very large 'upper' values don't lead to a positive outcome.
-             # Could happen if W is extremely large or desired_final_value is unachievable.
-            return float('inf')
-
-        # Heuristic to increase upper if it's stuck at 0 or too small
-        if upper == 0:
-            if W > 0 and T > 0:
-                upper = W * T * 2 # Initial guess based on total withdrawals
-            elif desired_final_value > 0:
-                upper = desired_final_value * 2
-            else: # Both W and desired_final_value are 0 or negative
-                upper = 1000.0 # Default small positive if all else fails
-        else:
-            upper *= 2
-            
-        if upper > current_app.config['PV_MAX_GUESS_LIMIT']: 
-            # If even with PV_MAX_GUESS_LIMIT, we can't meet the desired_final_value
-            if simulate_final_balance(current_app.config['PV_MAX_GUESS_LIMIT'], r, i, W, T, withdrawal_time, desired_final_value) < 0:
-                return float('inf')
-            else: # PV_MAX_GUESS_LIMIT is enough, so search within it.
-                upper = current_app.config['PV_MAX_GUESS_LIMIT']
-                break 
+    lower = desired_final_value if desired_final_value > 0 else 0.0
     
-    # If lower itself is sufficient (can happen if desired_final_value is low/negative or W is low/negative)
-    if simulate_final_balance(lower, r, i, W, T, withdrawal_time, desired_final_value) >= 0:
-        # And if the range is already very small (e.g. lower was inf, or upper didn't need to expand much)
-        if upper == float('inf') or (upper - lower) <= current_app.config['DEFAULT_TOLERANCE']:
-             return lower if lower != float('-inf') else 0.0 # Avoid returning -inf if W is very negative
+    # Rough upper bound heuristic
+    if W_initial > 0:
+        upper = (W_initial * total_T_from_periods * 2) + max(0, desired_final_value)
+    else: # W_initial is 0 or negative
+        upper = max(1000.0, desired_final_value * 2) # Ensure upper is somewhat positive if DFV is small/zero
+        if upper < lower: # Case where DFV is negative
+             upper = lower + 1000.0
+
+
+    # Ensure upper is significantly larger than lower to start, especially if W_initial is large
+    # This is a more robust starting upper bound if W_initial is substantial.
+    # Heuristic: sum of all (inflated) withdrawals + desired final value, then add buffer.
+    # For simplicity, using a multiplier on W_initial * T as a proxy.
+    estimated_total_withdrawals = W_initial * total_T_from_periods 
+    # A more generous upper bound if W_initial is positive
+    if W_initial > 0:
+        potential_upper = (estimated_total_withdrawals * 1.5) + max(0, desired_final_value) * 1.5
+        upper = max(upper, potential_upper)
+
+
+    upper = max(upper, lower + 100.0) # Ensure there's a search range
+
+    # Maximize upper up to PV_MAX_GUESS_LIMIT if simulate_final_balance is still negative
+    iteration_count_upper_bound_search = 0
+    max_iterations_upper_bound = 100 # Safety break
+
+    # We need simulate_final_balance to take W_initial, not W (which was the old param name)
+    while simulate_final_balance(upper, W_initial, withdrawal_time, rates_periods, desired_final_value) < 0:
+        iteration_count_upper_bound_search += 1
+        if iteration_count_upper_bound_search > max_iterations_upper_bound:
+            return float('inf') # Cannot find a suitable upper bound
+        
+        upper_multiplier = 2.0
+        # If upper is very small or zero, and W_initial is positive, give it a more substantial boost
+        if upper < W_initial * total_T_from_periods and W_initial > 0 :
+             upper = W_initial * total_T_from_periods * upper_multiplier
+        else:
+            upper *= upper_multiplier
+
+        if upper > current_app.config['PV_MAX_GUESS_LIMIT']:
+            upper = current_app.config['PV_MAX_GUESS_LIMIT']
+            if simulate_final_balance(upper, W_initial, withdrawal_time, rates_periods, desired_final_value) < 0:
+                return float('inf') # Even PV_MAX_GUESS_LIMIT is not enough
+            break 
+    
+    # If lower itself is sufficient
+    if simulate_final_balance(lower, W_initial, withdrawal_time, rates_periods, desired_final_value) >= 0:
+         # And if the range is already very small
+        if (upper == float('inf') and lower == float('inf')) or (upper - lower) <= current_app.config['DEFAULT_TOLERANCE']:
+             return lower if lower != float('-inf') else 0.0
 
 
     # Bisection search
-    while (upper - lower) > current_app.config['DEFAULT_TOLERANCE']: 
+    iteration_count_bisection = 0
+    max_iterations_bisection = 100
+    while (upper - lower) > current_app.config['DEFAULT_TOLERANCE']:
+        iteration_count_bisection +=1
+        if iteration_count_bisection > max_iterations_bisection: break
+
         mid = (lower + upper) / 2.0
-        # Prevent infinite loop if mid gets stuck due to precision limits with inf
-        if mid == lower or mid == upper or mid == float('inf'):
-            break 
-        if simulate_final_balance(mid, r, i, W, T, withdrawal_time, desired_final_value) < 0:
+        if mid == lower or mid == upper or mid == float('inf'): break
+
+        if simulate_final_balance(mid, W_initial, withdrawal_time, rates_periods, desired_final_value) < 0:
             lower = mid
         else:
             upper = mid
+            
+    # Final check on 'upper' as it's the one that should satisfy the condition or be very close
+    if simulate_final_balance(upper, W_initial, withdrawal_time, rates_periods, desired_final_value) < -current_app.config['DEFAULT_TOLERANCE']:
+        # If 'upper' significantly misses, and 'lower' (which was too low) is float('inf'), something is wrong.
+        # This might indicate an unachievable scenario not caught by upper bound search.
+        if lower == float('inf'): return float('inf')
+        # If 'lower' is a valid number but didn't meet the criteria, and 'upper' also doesn't,
+        # it implies no solution was found in the given constraints.
+        # However, bisection should converge such that 'upper' is the smallest value satisfying the condition.
+        # If 'upper' is still failing significantly, it might be an issue if the function isn't monotonic
+        # or if the bounds were not set correctly.
+        # For now, returning 'upper' is standard, but this check indicates potential issues.
+        # If W_initial is very high, this might be the best we can do, returning a PV that gets close.
+        pass # Keep upper as the result from bisection
+
     return upper
 
-def find_max_annual_expense(P, r, i, T, withdrawal_time, desired_final_value=0.0):
+
+def find_max_annual_expense(P, withdrawal_time, rates_periods, desired_final_value=0.0):
     """
-    Find the maximum initial annual withdrawal (W) sustainable from portfolio P for T years,
-    aiming for a specific desired_final_value. Uses a bisection method.
+    Find the maximum initial annual withdrawal (W_initial) sustainable from portfolio P
+    for the duration specified in rates_periods, aiming for a specific desired_final_value.
+    Uses a bisection method.
 
     Args:
         P (float): Initial portfolio value.
-        r (float): Annual rate of return.
-        i (float): Annual inflation rate.
-        T (int): Time horizon in years.
         withdrawal_time (str): "start" or "end".
-        desired_final_value (float, optional): The desired portfolio value at the end of T years. Defaults to 0.0.
-
-    Returns:
-        float: Maximum sustainable initial annual withdrawal.
+        rates_periods (list of dicts): List of rate periods, e.g.,
+                                       [{'duration': D_years, 'r': R_decimal, 'i': I_decimal}, ...].
+        desired_final_value (float, optional): Target value. Defaults to 0.0.
     """
-    lower = 0.0 # Minimum possible W is 0
+    if not rates_periods:
+        raise ValueError("rates_periods list cannot be empty.")
 
-    # If T=0, no withdrawals can occur over time. Max W is effectively 0.
-    # The portfolio P is simply compared to desired_final_value.
-    # If P >= desired_final_value, a W=0 is sustainable. Otherwise, it's not.
-    if T == 0:
-        return 0.0
+    total_T_from_periods = sum(p.get('duration', 0) for p in rates_periods)
 
-    # Calculate PV of the desired final target.
-    # Given r validation (-50% to 100%), 1+r is always > 0.
-    pv_of_final_target = desired_final_value / ((1 + r) ** T)
+    if total_T_from_periods == 0:
+        return 0.0 # No withdrawals possible over zero time
+
+    lower = 0.0
     
-    P_for_withdrawals = P - pv_of_final_target
-
-    if P_for_withdrawals <= 0:
-        # If the initial portfolio isn't even enough to cover the discounted desired final value,
-        # then no withdrawals can be made. We should also check if W=0 is valid.
-        if simulate_final_balance(P, r, i, 0, T, withdrawal_time, desired_final_value) >= 0:
-            return 0.0 # W=0 is sustainable and meets the desired_final_value goal
-        else:
-            # This implies P < desired_final_value even with zero withdrawals, which P_for_withdrawals <=0 should catch.
-            # Or, if desired_final_value is very high, P_for_withdrawals is negative.
-            return 0.0 # Cannot sustain any positive withdrawal.
-
-    # Estimate upper bound for W using P_for_withdrawals
-    if r != i:
-        # Annuity factor for present value of a growing annuity
-        annuity_factor_denominator = (1 - ((1 + i) / (1 + r))**T)
-        if annuity_factor_denominator <= 0: # Avoid division by zero or negative if r < i and T makes factor non-positive
-            upper = current_app.config['W_MIN_GUESS_FOR_MAX_EXPENSE'] # Fallback to a minimal guess
-        else:
-            upper = P_for_withdrawals * (r - i) / annuity_factor_denominator
-    else: # r == i
-        # Annuity factor for present value of a level annuity (in real terms)
-        if T <= 0 : # Should be caught by initial T==0 check, but for safety
+    # Heuristic for upper bound
+    if total_T_from_periods > 0:
+        # Estimate based on average withdrawal if portfolio just depletes to desired_final_value
+        # This is a very rough estimate.
+        avg_r = sum(p['r'] * p['duration'] for p in rates_periods) / total_T_from_periods if total_T_from_periods > 0 else 0
+        # Effective principal available for withdrawals over the period
+        P_adjusted_for_dfv = P - (desired_final_value / ((1 + avg_r)**total_T_from_periods if (1 + avg_r) > 0 else 1))
+        
+        if P_adjusted_for_dfv <= 0: # If P is not enough to even reach DFV without withdrawals
             upper = 0.0
-        elif (1 + i) == 0: # r = i = -1, implies infinite PV for any W > 0
-            upper = 0.0 # No sustainable W unless P_for_withdrawals is also infinite
         else:
-            upper = P_for_withdrawals * (1 + i) / T
-            
-    # Ensure upper is not negative and has a minimum floor if it's positive, otherwise 0.
-    if upper <=0 : # If calculated upper is non-positive
+            # Simple average withdrawal guess
+            upper = (P_adjusted_for_dfv / (total_T_from_periods / 1.5)) if total_T_from_periods > 0 else 0 # Added safety factor 1.5
+            upper = max(upper, current_app.config.get('W_MIN_GUESS_FOR_MAX_EXPENSE', 1.0))
+    else: # total_T_from_periods is 0
+        upper = 0.0 
+        
+    upper = max(upper, current_app.config.get('W_MIN_GUESS_FOR_MAX_EXPENSE', 1.0))
+    if P <= 0 and desired_final_value <=0 : # If portfolio is zero or negative, and no positive target, max W is 0
         upper = 0.0
-    else: # If calculated upper is positive, ensure it's at least W_MIN_GUESS_FOR_MAX_EXPENSE
-        upper = max(upper, current_app.config['W_MIN_GUESS_FOR_MAX_EXPENSE'])
+
+    # If P is positive but upper is 0 (e.g. P_adjusted_for_dfv was negative), check if W=0 is valid
+    if upper == 0.0 and P > 0:
+        if simulate_final_balance(P, 0, withdrawal_time, rates_periods, desired_final_value) >= 0:
+            return 0.0 # W=0 is sustainable
+        # else: P is not enough even for W=0 to reach DFV, so need to find a negative W if that's allowed, or stick to 0.
+        # Assuming W must be non-negative.
 
 
-    # If the initial check determined P_for_withdrawals <= 0, and W=0 works, upper would be 0 here.
-    # If upper is 0, it means no positive withdrawal is possible.
-    if upper == 0.0:
-        # Final check: does W=0 actually meet the condition?
-        # (actual_final_balance - desired_final_value) >= 0
-        if simulate_final_balance(P, r, i, 0, T, withdrawal_time, desired_final_value) >= 0:
-            return 0.0
-        else:
-            # This implies an edge case where P_for_withdrawals was positive, but annuity formulas yielded W_upper <= 0.
-            # This could happen if r, i, T relationship is unusual (e.g. r < i significantly).
-            # Effectively, no positive withdrawal can be sustained.
-            return 0.0
-
-
-    # Bisection search for W
-    # Target: find highest W such that (actual_final_balance - desired_final_value) >= 0
+    # Bisection search for W_initial
     iteration_count = 0
-    max_iterations = 100 # Safety break for bisection
+    max_iterations = 100 # Safety break
     
-    # Check if the 'upper' W itself is too high (results in missing the target)
-    # If simulate_final_balance with 'upper' W is already < 0, then 'upper' is too high.
-    # We need an 'upper' that we know is *at least* sustainable or better.
-    # The bisection expects:
-    # simulate_final_balance(P, ..., lower_W, ...) >= 0 (lower_W is sustainable)
-    # simulate_final_balance(P, ..., upper_W, ...) < 0 (upper_W is NOT sustainable)
-    # The current 'upper' is an estimate. If it's not sustainable, we need to find one that is, or reduce it.
-    # Let's refine the bisection loop slightly.
-    # 'lower' = known sustainable W (initially 0)
-    # 'upper' = potentially unsustainable W (our estimate, or higher if estimate is sustainable)
-
-    # If our initial 'upper' estimate for W results in not meeting the target,
-    # it means this 'upper' W is too high to begin with. We'll use it as the top of our search.
-    # If it *does* meet the target, our 'lower' can become this 'upper', and we need a new 'upper'.
-    # This part of bisection is tricky for finding max W.
-    # Standard bisection for this:
-    # If func(mid) < 0 (missed target, W too high), then true_max_W is in [lower, mid] -> upper = mid
-    # If func(mid) >= 0 (met target, W sustainable), then true_max_W is in [mid, upper] -> lower = mid
-
+    # Loop while the difference between upper and lower is greater than tolerance
     while (upper - lower) > current_app.config['DEFAULT_TOLERANCE']:
         iteration_count += 1
-        if iteration_count > max_iterations: break
-        mid = (lower + upper) / 2.0
-        if mid == lower or mid == upper: break # Precision limit reached
+        if iteration_count > max_iterations:
+            break 
+        
+        mid_W = (lower + upper) / 2.0
+        if mid_W == lower or mid_W == upper: # Precision limit reached
+            break
 
-        if simulate_final_balance(P, r, i, mid, T, withdrawal_time, desired_final_value) < 0:
-            upper = mid  # W_mid is too high, so it becomes the new upper bound
+        # If simulating with mid_W results in a final balance less than desired,
+        # then mid_W is too high. So, new upper bound is mid_W.
+        if simulate_final_balance(P, mid_W, withdrawal_time, rates_periods, desired_final_value) < 0:
+            upper = mid_W
+        # Otherwise, mid_W is sustainable or more than sustainable.
+        # So, new lower bound is mid_W, try for a higher W.
         else:
-            lower = mid  # W_mid is sustainable, so it becomes the new lower bound (try for higher W)
+            lower = mid_W
             
-    # 'lower' should be the highest sustainable W found.
-    # A final check on 'lower' to ensure it's truly valid.
-    if simulate_final_balance(P, r, i, lower, T, withdrawal_time, desired_final_value) < -current_app.config['DEFAULT_TOLERANCE']:
-         # If even 'lower' doesn't meet target (within tolerance), means no W could be found.
-        return 0.0 
+    # 'lower' should be the highest sustainable W_initial found.
+    # Final check on 'lower' to ensure it's truly valid and non-negative.
+    if lower < 0: return 0.0 # Should not happen if initial lower is 0.0
+
+    if simulate_final_balance(P, lower, withdrawal_time, rates_periods, desired_final_value) < -current_app.config['DEFAULT_TOLERANCE']:
+        # If even 'lower' doesn't meet target (within tolerance), means no positive W could be found.
+        return 0.0
         
     return lower

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -43,39 +43,54 @@
           <div class="form-group">
             <label for="scenario{{n}}_W_slider">Annual Expenses (W):</label>
             <input type="range" id="scenario{{n}}_W_slider" name="scenario{{n}}_W" min="0" max="1000000" step="1000" value="{{ request.form.get('scenario' ~ n ~ '_W', '') }}">
-            <input type="number" id="scenario{{n}}_W_input" class="number-input" name="scenario{{n}}_W" value="{{ request.form.get('scenario' ~ n ~ '_W', '') }}" placeholder="e.g., 50000">
+            <input type="number" id="scenario{{n}}_W_input" class="number-input" name="scenario{{n}}_W" value="{{ request.form.get('scenario{}__W'.format(n), scenario.W_form) }}" placeholder="e.g., 50000">
           </div>
           <div class="form-group">
-            <label for="scenario{{n}}_r_slider">Expected Annual Return (%):</label>
-            <input type="range" id="scenario{{n}}_r_slider" name="scenario{{n}}_r" min="0" max="15" step="0.01" value="{{ request.form.get('scenario' ~ n ~ '_r', '') }}">
-            <input type="number" id="scenario{{n}}_r_input" class="number-input" name="scenario{{n}}_r" value="{{ request.form.get('scenario' ~ n ~ '_r', '') }}" placeholder="e.g., 7">
+            <label for="scenario{{n}}_r_slider">Overall Return (%) (Fallback):</label>
+            <input type="range" id="scenario{{n}}_r_slider" name="scenario{{n}}_r" min="0" max="15" step="0.01" value="{{ request.form.get('scenario{}__r'.format(n), scenario.r_form) }}">
+            <input type="number" id="scenario{{n}}_r_input" class="number-input" name="scenario{{n}}_r" value="{{ request.form.get('scenario{}__r'.format(n), scenario.r_form) }}" placeholder="e.g., 7">
           </div>
           <div class="form-group">
-            <label for="scenario{{n}}_i_slider">Expected Annual Inflation (%):</label>
-            <input type="range" id="scenario{{n}}_i_slider" name="scenario{{n}}_i" min="0" max="10" step="0.01" value="{{ request.form.get('scenario' ~ n ~ '_i', '') }}">
-            <input type="number" id="scenario{{n}}_i_input" class="number-input" name="scenario{{n}}_i" value="{{ request.form.get('scenario' ~ n ~ '_i', '') }}" placeholder="e.g., 2">
+            <label for="scenario{{n}}_i_slider">Overall Inflation (%) (Fallback):</label>
+            <input type="range" id="scenario{{n}}_i_slider" name="scenario{{n}}_i" min="0" max="10" step="0.01" value="{{ request.form.get('scenario{}__i'.format(n), scenario.i_form) }}">
+            <input type="number" id="scenario{{n}}_i_input" class="number-input" name="scenario{{n}}_i" value="{{ request.form.get('scenario{}__i'.format(n), scenario.i_form) }}" placeholder="e.g., 2">
           </div>
           <div class="form-group">
-            <label for="scenario{{n}}_T_slider">Retirement Duration (years):</label>
-            <input type="range" id="scenario{{n}}_T_slider" name="scenario{{n}}_T" min="10" max="100" step="1" value="{{ request.form.get('scenario' ~ n ~ '_T', '') }}">
-            <input type="number" id="scenario{{n}}_T_input" class="number-input" name="scenario{{n}}_T" value="{{ request.form.get('scenario' ~ n ~ '_T', '') }}" placeholder="e.g., 30">
+            <label for="scenario{{n}}_T_slider">Total Duration (years) (Fallback):</label>
+            <input type="range" id="scenario{{n}}_T_slider" name="scenario{{n}}_T" min="10" max="100" step="1" value="{{ request.form.get('scenario{}__T'.format(n), scenario.T_form) }}">
+            <input type="number" id="scenario{{n}}_T_input" class="number-input" name="scenario{{n}}_T" value="{{ request.form.get('scenario{}__T'.format(n), scenario.T_form) }}" placeholder="e.g., 30">
           </div>
+
+          <div class="periodic-rates-section">
+            <h5>Periodic Rates (Optional for Scenario {{n}})</h5>
+            {% for k in range(1, 4) %}
+            <div class="form-group period-group">
+              <label for="scenario{{n}}_period{{k}}_duration">P{{k}} Dur.:</label>
+              <input type="number" name="scenario{{n}}_period{{k}}_duration" id="scenario{{n}}_period{{k}}_duration" value="{{ request.form.get('scenario{}period{}_duration'.format(n, k), scenario.get('period{}_duration_form'.format(k), '')) }}" min="0" placeholder="Years">
+              <label for="scenario{{n}}_period{{k}}_r" style="margin-left: 10px;">P{{k}} Ret(%):</label>
+              <input type="number" name="scenario{{n}}_period{{k}}_r" id="scenario{{n}}_period{{k}}_r" step="0.1" value="{{ request.form.get('scenario{}period{}_r'.format(n, k), scenario.get('period{}_r_form'.format(k), '')) }}" placeholder="%">
+              <label for="scenario{{n}}_period{{k}}_i" style="margin-left: 10px;">P{{k}} Inf(%):</label>
+              <input type="number" name="scenario{{n}}_period{{k}}_i" id="scenario{{n}}_period{{k}}_i" step="0.1" value="{{ request.form.get('scenario{}period{}_i'.format(n, k), scenario.get('period{}_i_form'.format(k), '')) }}" placeholder="%">
+            </div>
+            {% endfor %}
+          </div>
+
           <div class="form-group">
             <label>Withdrawal Timing:</label>
-            <input type="radio" name="scenario{{n}}_withdrawal_time" value="start" {% if request.form.get('scenario' ~ n ~ '_withdrawal_time', 'start') == 'start' %}checked{% endif %}> Start of Year
-            <input type="radio" name="scenario{{n}}_withdrawal_time" value="end" {% if request.form.get('scenario' ~ n ~ '_withdrawal_time', 'start') == 'end' %}checked{% endif %}> End of Year
+            <input type="radio" name="scenario{{n}}_withdrawal_time" value="start" {% if request.form.get('scenario{}withdrawal_time'.format(n), scenario.withdrawal_time_form) == 'start' %}checked{% endif %}> Start of Year
+            <input type="radio" name="scenario{{n}}_withdrawal_time" value="end" {% if request.form.get('scenario{}withdrawal_time'.format(n), scenario.withdrawal_time_form) == 'end' %}checked{% endif %}> End of Year
           </div>
           <div class="form-group">
             <label for="scenario{{n}}_D">Desired Final Portfolio Value ($):</label>
-            <input type="number" name="scenario{{n}}_D" id="scenario{{n}}_D" value="0.0" step="any" min="0">
+            <input type="number" name="scenario{{n}}_D" id="scenario{{n}}_D" value="{{ request.form.get('scenario{}__D'.format(n), scenario.D_form) }}" step="any" min="0">
           </div>
           <div class="form-group">
             <label>Enable Scenario {{ n }}:</label>
-            <input type="checkbox" name="scenario{{n}}_enabled" {% if request.form.get('scenario' ~ n ~ '_enabled') == "on" or n == 1 %}checked{% endif %}>
+            <input type="checkbox" name="scenario{{n}}_enabled" {% if request.form.get('scenario{}enabled'.format(n)) == "on" or (not request.form and scenario.enabled) %}checked{% endif %}>
           </div>
-          {% if scenarios and scenarios|length >= n and scenarios[n-1].enabled %}
+          {% if scenario.fire_number_display and scenario.fire_number_display != "N/A" %}
           <div class="result-section">
-            <p><strong>FIRE Number:</strong> ${{ "{:,.2f}".format(scenarios[n-1].fire_number) }}</p>
+            <p><strong>FIRE Number:</strong> {{ scenario.fire_number_display }}</p>
           </div>
           {% endif %}
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,20 +20,46 @@
     <form method="post" action="/">
       <div class="form-group">
         <label for="W">Annual Expenses (in today's dollars):</label>
-        <input type="number" name="W" id="W" required>
+        <input type="number" name="W" id="W" value="{{ request.form.get('W', '20000') }}" required>
+      </div>
+      
+      <div class="form-group">
+        <label for="r">Overall Annual Return (%) (Fallback):</label>
+        <input type="number" name="r" id="r" step="0.1" value="{{ request.form.get('r', '5') }}" required>
+        <small>Used if no periodic rates are specified below.</small>
       </div>
       <div class="form-group">
-        <label for="r">Expected Annual Return (%):</label>
-        <input type="number" name="r" id="r" step="0.1" required>
+        <label for="i">Overall Annual Inflation (%) (Fallback):</label>
+        <input type="number" name="i" id="i" step="0.1" value="{{ request.form.get('i', '2') }}" required>
+        <small>Used if no periodic rates are specified below.</small>
       </div>
       <div class="form-group">
-        <label for="i">Expected Annual Inflation (%):</label>
-        <input type="number" name="i" id="i" step="0.1" required>
+        <label for="T">Total Duration (years) (Fallback):</label>
+        <input type="number" name="T" id="T" value="{{ request.form.get('T', '30') }}" required>
+        <small>Used if no periodic rates are specified below. If using periods, total duration is sum of period durations.</small>
+      </div>
+
+      <hr>
+      <h3>Periodic Rate Configuration (Optional)</h3>
+      <p><small>If any period duration is specified, these periodic rates will override the overall fallback rates above. Unspecified periods will be ignored.</small></p>
+      
+      {% for k in range(1, 4) %}
+      <h4>Period {{ k }}</h4>
+      <div class="form-group">
+        <label for="period{{k}}_duration">Period {{ k }} Duration (years):</label>
+        <input type="number" name="period{{k}}_duration" id="period{{k}}_duration" value="{{ request.form.get('period{}_duration'.format(k), '') }}" min="0">
       </div>
       <div class="form-group">
-        <label for="T">Retirement Duration (years):</label>
-        <input type="number" name="T" id="T" required>
+        <label for="period{{k}}_r">Period {{ k }} Return (%):</label>
+        <input type="number" name="period{{k}}_r" id="period{{k}}_r" step="0.1" value="{{ request.form.get('period{}_r'.format(k), '') }}">
       </div>
+      <div class="form-group">
+        <label for="period{{k}}_i">Period {{ k }} Inflation (%):</label>
+        <input type="number" name="period{{k}}_i" id="period{{k}}_i" step="0.1" value="{{ request.form.get('period{}_i'.format(k), '') }}">
+      </div>
+      {% endfor %}
+      <hr>
+
       <div class="form-group radio-group">
         <label>Withdrawal Timing:</label>
         <input type="radio" name="withdrawal_time" value="start" id="start" {% if withdrawal_time == 'start' or not withdrawal_time %}checked{% endif %}>
@@ -43,7 +69,7 @@
       </div>
       <div class="form-group">
         <label for="D">Desired Final Portfolio Value ($):</label>
-        <input type="number" name="D" id="D" value="{{ D | default('0.0') }}" step="any" min="0">
+        <input type="number" name="D" id="D" value="{{ request.form.get('D', '0.0') }}" step="any" min="0">
         <small>Optional. The portfolio value you want remaining at the end of the term.</small>
       </div>
       <input type="submit" value="Calculate">

--- a/tests/test_finance_core.py
+++ b/tests/test_finance_core.py
@@ -18,176 +18,150 @@ class TestFinancialCalculations(unittest.TestCase):
     def test_annual_simulation_scenarios(self):
         test_cases = [
             {
-                "name": "Time End Basic",
-                "PV": 100000, "r": 0.05, "i": 0.02, "W": 4000, "T": 1, "withdrawal_time": TIME_END,
-                "expected_balances": [100000.00, 101000.00], # Initial PV, End of Year 1
+                "name": "Single Period - Time End Basic",
+                "PV": 100000, "W_initial": 4000, "withdrawal_time": TIME_END,
+                "rates_periods": [{'duration': 1, 'r': 0.05, 'i': 0.02}],
+                "expected_balances": [100000.00, 101000.00],
                 "expected_withdrawals": [4000.00],
-                "expected_years_len": 2 # T+1
+                "total_T": 1
             },
             {
-                "name": "Time Start Basic",
-                "PV": 100000, "r": 0.05, "i": 0.02, "W": 4000, "T": 1, "withdrawal_time": TIME_START,
-                "expected_balances": [96000.00, 100800.00], # After 1st withdrawal, End of Year 1
+                "name": "Single Period - Time Start Basic",
+                "PV": 100000, "W_initial": 4000, "withdrawal_time": TIME_START,
+                "rates_periods": [{'duration': 1, 'r': 0.05, 'i': 0.02}],
+                "expected_balances": [96000.00, 100800.00],
                 "expected_withdrawals": [4000.00],
-                "expected_years_len": 2
+                "total_T": 1
             },
             {
-                "name": "Zero Rates Time End",
-                "PV": 100000, "r": 0.00, "i": 0.00, "W": 4000, "T": 2, "withdrawal_time": TIME_END,
-                "expected_balances": [100000.00, 96000.00, 92000.00],
-                "expected_withdrawals": [4000.00, 4000.00],
-                "expected_years_len": 3
+                "name": "Multi Period - Example from problem description",
+                "PV": 100000, "W_initial": 1000, "withdrawal_time": TIME_END,
+                "rates_periods": [
+                    {'duration': 1, 'r': 0.05, 'i': 0.02}, 
+                    {'duration': 1, 'r': 0.06, 'i': 0.03}
+                ],
+                "expected_balances": [100000.00, 104000.00, 109220.00],
+                "expected_withdrawals": [1000.00, 1020.00],
+                "total_T": 2
             },
+            {
+                "name": "Multi Period - Zero rates, 3 years total",
+                "PV": 100000, "W_initial": 1000, "withdrawal_time": TIME_END,
+                "rates_periods": [
+                    {'duration': 2, 'r': 0.00, 'i': 0.00}, 
+                    {'duration': 1, 'r': 0.00, 'i': 0.00}
+                ],
+                "expected_balances": [100000.00, 99000.00, 98000.00, 97000.00],
+                "expected_withdrawals": [1000.00, 1000.00, 1000.00],
+                "total_T": 3
+            }
         ]
 
         for case in test_cases:
             with self.subTest(name=case["name"]):
                 years, balances, withdrawals = annual_simulation(
-                    case["PV"], case["r"], case["i"], case["W"], case["T"], case["withdrawal_time"]
+                    case["PV"], case["W_initial"], case["withdrawal_time"], case["rates_periods"]
                 )
-                # Verify years array
-                self.assertEqual(len(years), case["expected_years_len"])
-                self.assertListEqual(list(years), list(np.arange(0, case["T"] + 1)))
+                self.assertEqual(len(years), case["total_T"] + 1)
+                self.assertListEqual(list(years), list(np.arange(0, case["total_T"] + 1)))
                 
-                # Verify balances list
                 self.assertEqual(len(balances), len(case["expected_balances"]))
                 for bal_actual, bal_expected in zip(balances, case["expected_balances"]):
                     self.assertAlmostEqual(bal_actual, bal_expected, places=2)
-
-                # Verify withdrawals list
                 self.assertEqual(len(withdrawals), len(case["expected_withdrawals"]))
                 for wd_actual, wd_expected in zip(withdrawals, case["expected_withdrawals"]):
                     self.assertAlmostEqual(wd_actual, wd_expected, places=2)
-                
-                # Verify final balance implicitly via the last element of expected_balances
-                if case["expected_balances"]:
+                if case["expected_balances"]: # balances includes initial PV
                     self.assertAlmostEqual(balances[-1], case["expected_balances"][-1], places=2)
 
     def test_simulate_final_balance_logic(self):
         test_cases = [
             {
-                "name": "DFV Zero", "PV": 100000, "r": 0.05, "i": 0.02, "W": 4000, "T": 1, 
-                "withdrawal_time": TIME_END, "desired_final_value": 0.0, "expected_diff": 101000.00
+                "name": "Single Period - DFV Zero", 
+                "PV": 100000, "W_initial": 4000, "withdrawal_time": TIME_END, 
+                "rates_periods": [{'duration': 1, 'r': 0.05, 'i': 0.02}],
+                "desired_final_value": 0.0, "expected_diff": 101000.00
             },
             {
-                "name": "DFV Positive", "PV": 100000, "r": 0.05, "i": 0.02, "W": 4000, "T": 1,
-                "withdrawal_time": TIME_END, "desired_final_value": 100000.0, "expected_diff": 1000.00 # 101000 - 100000
-            },
-            {
-                "name": "DFV Higher", "PV": 100000, "r": 0.05, "i": 0.02, "W": 4000, "T": 1,
-                "withdrawal_time": TIME_END, "desired_final_value": 102000.0, "expected_diff": -1000.00 # 101000 - 102000
-            },
-            # Test with TIME_START as well
-            {
-                "name": "DFV Zero Time Start", "PV": 100000, "r": 0.05, "i": 0.02, "W": 4000, "T": 1,
-                "withdrawal_time": TIME_START, "desired_final_value": 0.0, "expected_diff": 100800.00 
-            },
-             {
-                "name": "DFV Positive Time Start", "PV": 100000, "r": 0.05, "i": 0.02, "W": 4000, "T": 1,
-                "withdrawal_time": TIME_START, "desired_final_value": 100000.0, "expected_diff": 800.00 # 100800 - 100000
+                "name": "Multi Period - DFV Positive", 
+                "PV": 100000, "W_initial": 1000, "withdrawal_time": TIME_END,
+                "rates_periods": [
+                    {'duration': 1, 'r': 0.05, 'i': 0.02}, 
+                    {'duration': 1, 'r': 0.06, 'i': 0.03}
+                ],
+                "desired_final_value": 100000.0, "expected_diff": 9220.00 # 109220 - 100000
             },
         ]
-
         for case in test_cases:
             with self.subTest(name=case["name"]):
                 actual_diff = simulate_final_balance(
-                    case["PV"], case["r"], case["i"], case["W"], case["T"], 
-                    case["withdrawal_time"], case["desired_final_value"]
+                    case["PV"], case["W_initial"], case["withdrawal_time"], 
+                    case["rates_periods"], case["desired_final_value"]
                 )
                 self.assertAlmostEqual(actual_diff, case["expected_diff"], places=2)
 
-
-    # Tests for find_required_portfolio
     def test_find_required_portfolio_scenarios(self):
         test_cases = [
             {
-                "name": "Basic Time End DFV Zero",
-                "W": 40000, "r": 0.07, "i": 0.03, "T": 25, "withdrawal_time": TIME_END, "desired_final_value": 0.0,
-                "expected_pv": 614223.147699631, "delta": 0.02
+                "name": "Single Period - Basic Time End DFV Zero",
+                "W_initial": 40000, "withdrawal_time": TIME_END, "desired_final_value": 0.0,
+                "rates_periods": [{'duration': 25, 'r': 0.07, 'i': 0.03}],
+                "expected_pv": 614223.147699631, "delta": 0.02 
             },
             {
-                "name": "Basic Time Start DFV Zero",
-                "W": 40000, "r": 0.07, "i": 0.03, "T": 25, "withdrawal_time": TIME_START, "desired_final_value": 0.0,
-                "expected_pv": 657218.7680386053, "delta": 0.02
-            },
-            {
-                "name": "R equals I DFV Zero",
-                "W": 50000, "r": 0.04, "i": 0.04, "T": 20, "withdrawal_time": TIME_END, "desired_final_value": 0.0,
-                "expected_pv": 961538.4687024814, "delta": 0.02
-            },
-            {
-                "name": "Basic Time End with DFV",
-                "W": 40000, "r": 0.07, "i": 0.03, "T": 25, "withdrawal_time": TIME_END, "desired_final_value": 100000.0,
-                "expected_pv": 632648.0657264077, "delta": 0.02 
-            },
-            {
-                "name": "Basic Time Start with DFV",
-                "W": 40000, "r": 0.07, "i": 0.03, "T": 25, "withdrawal_time": TIME_START, "desired_final_value": 100000.0,
-                "expected_pv": 676933.4252837093, "delta": 0.02 
+                "name": "Multi Period - 2 periods, varying rates",
+                "W_initial": 1000, "withdrawal_time": TIME_END, "desired_final_value": 100000.0,
+                 "rates_periods": [
+                    {'duration': 1, 'r': 0.05, 'i': 0.02}, 
+                    {'duration': 1, 'r': 0.06, 'i': 0.03}
+                ], # Total T=2. Expected final balance with PV=X should be DFV.
+                # For W=1000, DFV=100000, Balances EOY0 = X*1.05-1000, EOY1 = (X*1.05-1000)*1.06 - 1020
+                # (X*1.05-1000)*1.06 - 1020 = 100000 => X*1.05*1.06 - 1060 - 1020 = 100000
+                # X * 1.113 - 2080 = 100000 => X * 1.113 = 102080 => X = 102080 / 1.113 = 91716.08
+                "expected_pv": 91716.08, "delta": 0.02
             },
         ]
-
         for case in test_cases:
             with self.subTest(name=case["name"]):
                 actual_pv = find_required_portfolio(
-                    case["W"], case["r"], case["i"], case["T"], case["withdrawal_time"], case["desired_final_value"]
+                    case["W_initial"], case["withdrawal_time"], case["rates_periods"], case["desired_final_value"]
                 )
                 self.assertAlmostEqual(actual_pv, case["expected_pv"], delta=case["delta"])
 
-    # Skipping test_frp_high_withdrawal_inf as it's hard to trigger float('inf')
-    # reliably without extreme values with current PV_MAX_GUESS_LIMIT.
-    # The conditional is assumed covered by code inspection for extreme scenarios.
-
-    # Tests for find_max_annual_expense
     def test_find_max_annual_expense_scenarios(self):
         test_cases = [
             {
-                "name": "Basic Time End DFV Zero",
-                "P": 1000000, "r": 0.06, "i": 0.025, "T": 30, "withdrawal_time": TIME_END, "desired_final_value": 0.0,
-                "expected_W": 55136.150245186924, "delta": 0.02 
+                "name": "Single Period - Basic Time End DFV Zero",
+                "P": 1000000, "withdrawal_time": TIME_END, "desired_final_value": 0.0,
+                "rates_periods": [{'duration': 30, 'r': 0.06, 'i': 0.025}],
+                "expected_W": 55136.150245186924, "delta": 0.02
             },
             {
-                "name": "Basic Time Start DFV Zero",
-                "P": 1000000, "r": 0.06, "i": 0.025, "T": 30, "withdrawal_time": TIME_START, "desired_final_value": 0.0,
-                "expected_W": 52015.24178500842, "delta": 0.02
-            },
-            {
-                "name": "R equals I DFV Zero",
-                "P": 800000, "r": 0.03, "i": 0.03, "T": 25, "withdrawal_time": TIME_END, "desired_final_value": 0.0,
-                "expected_W": 32960.0, "delta": 0.02 
-            },
-            {
-                "name": "Basic Time End with DFV",
-                "P": 1000000, "r": 0.06, "i": 0.025, "T": 30, "withdrawal_time": TIME_END, "desired_final_value": 200000.0,
-                "expected_W": 53216.191433902204, "delta": 0.02 
-            },
-            {
-                "name": "Basic Time Start with DFV",
-                "P": 1000000, "r": 0.06, "i": 0.025, "T": 30, "withdrawal_time": TIME_START, "desired_final_value": 200000.0,
-                "expected_W": 50203.959329836056, "delta": 0.02 
+                "name": "Multi Period - 2 periods, varying rates",
+                "P": 100000, "withdrawal_time": TIME_END, "desired_final_value": 0.0,
+                "rates_periods": [
+                    {'duration': 1, 'r': 0.05, 'i': 0.02}, 
+                    {'duration': 1, 'r': 0.06, 'i': 0.03}
+                ], # Total T=2
+                # Bal EOY0 = 100000*1.05 - W = 105000 - W
+                # Bal EOY1 = (105000-W)*1.06 - W*(1+0.02) = (105000-W)*1.06 - 1.02*W = 0
+                # 111300 - 1.06W - 1.02W = 0 => 111300 = 2.08W => W = 111300 / 2.08 = 53509.61
+                "expected_W": 53509.61, "delta": 0.02 
             },
         ]
-
         for case in test_cases:
             with self.subTest(name=case["name"]):
                 actual_W = find_max_annual_expense(
-                    case["P"], case["r"], case["i"], case["T"], case["withdrawal_time"], case["desired_final_value"]
+                    case["P"], case["withdrawal_time"], case["rates_periods"], case["desired_final_value"]
                 )
                 self.assertAlmostEqual(actual_W, case["expected_W"], delta=case["delta"])
 
-    def test_frp_high_withdrawal_scenario(self): # Renamed from _inf
-        W = 1e8 # 100 million
-        r = 0.01
-        i = 0.00
-        T = 50
+    def test_frp_high_withdrawal_scenario_single_period(self):
+        W_initial = 1e8 # 100 million
+        rates_periods = [{'duration': 50, 'r': 0.01, 'i': 0.00}]
         withdrawal_time = TIME_START
-        # This scenario tests a high withdrawal but is NOT expected to return float('inf')
-        # with the current PV_MAX_GUESS_LIMIT. It will return a very large PV.
-        # Expected value updated based on previous test run's actual output.
-        expected_PV = 3958807870.6488113
-        actual_PV = find_required_portfolio(W, r, i, T, withdrawal_time, desired_final_value=0.0) # Added desired_final_value
-        # Using a slightly larger absolute delta for this very large number,
-        # as 0.02 might be too strict relative to its magnitude if there are minor float variations.
+        expected_PV = 3958807870.6488113 
+        actual_PV = find_required_portfolio(W_initial, withdrawal_time, rates_periods, desired_final_value=0.0)
         self.assertAlmostEqual(actual_PV, expected_PV, delta=0.1)
 
 


### PR DESCRIPTION
This feature allows you to specify different rates of return and inflation for up to 3 distinct periods within your financial simulation.

Key changes:
- Core financial functions in `project/financial_calcs.py` (`annual_simulation`, `simulate_final_balance`, `find_required_portfolio`, `find_max_annual_expense`) updated to accept a `rates_periods` list (e.g., `[{'duration': D, 'r': R_decimal, 'i': I_decimal}, ...]`) instead of single r, i, T values.
- Backend routes (`index`, `update`, `compare`, `export_csv` in `project/routes.py`) modified to parse new form/query parameters for up to 3 periods, construct `rates_periods`, and pass it to financial functions. Includes fallback to single r, i, T inputs if no period data is provided.
- Frontend templates (`templates/index.html`, `templates/compare.html`) updated with new input fields for period durations and rates.
- Tests in `tests/test_finance_core.py` and `tests/test_app.py` updated to cover multi-period scenarios and fallback logic, including adjustments to mocks and expected data.
- README.md and code docstrings updated to document the new feature.