### PR TITLE
Fix: Resolve TemplateAssertionError for missing 'date' filter

### DIFF
--- a/project/routes.py
+++ b/project/routes.py
@@ -4,6 +4,7 @@ import plotly.graph_objects as go
 import plotly.offline as pyo
 import io
 import csv
+import datetime
 
 # Assuming app.py is in the root directory.
 # financial_calcs.py and constants.py are now in the same 'project' package.
@@ -321,6 +322,8 @@ def register_app_routes(app_instance):
                 # Pass rates_periods_data itself if result.html needs to be aware of multi-period for display
                 'rates_periods_info_json': rates_periods_data # For potential display or JS use on result page
             }
+            current_year = datetime.datetime.now().year
+            template_context['current_year'] = current_year
             return render_template('result.html', **template_context)
         else: # GET request: render with default values
             default_form_data = {
@@ -330,6 +333,8 @@ def register_app_routes(app_instance):
                 'period2_duration': '', 'period2_r': '', 'period2_i': '',
                 'period3_duration': '', 'period3_r': '', 'period3_i': '',
             }
+            current_year = datetime.datetime.now().year
+            default_form_data['current_year'] = current_year
             return render_template('index.html', **default_form_data)
 
 
@@ -574,14 +579,16 @@ def register_app_routes(app_instance):
                     sc[f'period{p_num}_r_form'] = ''
                     sc[f'period{p_num}_i_form'] = ''
                 default_scenarios_for_template.append(sc)
-            return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None)
+            current_year = datetime.datetime.now().year
+            return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None, current_year=current_year)
 
     @app_instance.route('/settings')
     def settings():
         """
         Handles GET requests for the settings page. Renders `settings.html`.
         """
-        return render_template("settings.html")
+        current_year = datetime.datetime.now().year
+        return render_template("settings.html", current_year=current_year)
 
     @app_instance.route('/export_csv')
     def export_csv():

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,7 +47,7 @@
   </main>
 
   <footer class="container mt-5 py-3 text-center text-muted">
-    <p>&copy; FIRE Calculator {% block year %}{{ 'now' | date('Y') }}{% endblock %}</p>
+    <p>&copy; FIRE Calculator {% block year %}{{ current_year }}{% endblock %}</p>
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>


### PR DESCRIPTION
I corrected a `jinja2.exceptions.TemplateAssertionError: No filter named 'date'` that occurred because the `base.html` template used a non-standard `{{ 'now' | date('Y') }}` filter.

The fix involves:
1. Modified `project/routes.py`:
    - Imported the `datetime` module.
    - Ensured that routes rendering templates which extend `base.html` (specifically `index`, `result`, `settings`, and `compare`) now calculate the current year and pass it to their respective template contexts as `current_year`.
2. Modified `templates/base.html`:
    - Replaced the problematic `{{ 'now' | date('Y') }}` in the footer with `{{ current_year }}` to use the directly passed variable.

This ensures the current year is displayed in the footer without relying on custom or missing Jinja filters, resolving the template error.