### PR TITLE
Fix: Correct url_for calls to resolve BuildError

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,20 +11,20 @@
 <body>
   <nav class="navbar navbar-expand-lg bg-body-tertiary">
     <div class="container-fluid">
-      <a class="navbar-brand" href="{{ url_for('routes.index') }}">FIRE Calc</a>
+      <a class="navbar-brand" href="{{ url_for('index') }}">FIRE Calc</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint == 'routes.index' %}active{% endif %}" aria-current="page" href="{{ url_for('routes.index') }}">Home</a>
+            <a class="nav-link {% if request.endpoint == 'index' %}active{% endif %}" aria-current="page" href="{{ url_for('index') }}">Home</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint == 'routes.compare' %}active{% endif %}" href="{{ url_for('routes.compare') }}">Compare</a>
+            <a class="nav-link {% if request.endpoint == 'compare' %}active{% endif %}" href="{{ url_for('compare') }}">Compare</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint == 'routes.settings' %}active{% endif %}" href="{{ url_for('routes.settings') }}">Settings</a>
+            <a class="nav-link {% if request.endpoint == 'settings' %}active{% endif %}" href="{{ url_for('settings') }}">Settings</a>
           </li>
         </ul>
         <button class="btn btn-outline-secondary" onclick="toggleTheme()">Toggle Theme</button>

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -27,7 +27,7 @@
     <select id="loadScenarioSelect" class="form-select" style="width: auto; display: inline-block;" onchange="loadScenario()"></select>
   </div>
 
-  <form method="post" action="{{ url_for('routes.compare') }}" id="compareForm" class="needs-validation" novalidate>
+  <form method="post" action="{{ url_for('compare') }}" id="compareForm" class="needs-validation" novalidate>
     <div class="scenario-container">
       {# The scenarios variable is passed from the route #}
       {% for scenario in scenarios %}
@@ -128,7 +128,7 @@
   {% endif %}
 
   <div class="mt-4"> {# Added spacing for back link #}
-    <a href="{{ url_for('routes.index') }}" class="btn btn-outline-secondary">← Back to Calculator</a>
+    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">← Back to Calculator</a>
   </div>
 </div>
 {% endblock %}
@@ -212,7 +212,7 @@
     function updateComparison() {
       $.ajax({
         type: "POST",
-        url: "{{ url_for('routes.compare') }}", // Use url_for for robustness
+        url: "{{ url_for('compare') }}", // Use url_for for robustness
         data: $("#compareForm").serialize(),
         headers: { "X-Requested-With": "XMLHttpRequest" },
         success: function(response) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
     {% if error %}
       <div class="alert alert-danger">{{ error }}</div>
     {% endif %}
-    <form method="post" action="{{ url_for('routes.index') }}" class="needs-validation" novalidate id="calculatorForm">
+    <form method="post" action="{{ url_for('index') }}" class="needs-validation" novalidate id="calculatorForm">
       <div class="mb-3">
         <label for="W" class="form-label">Annual Expenses (in today's dollars):</label>
         <input type="number" name="W" id="W" class="form-control" value="{{ request.form.get('W', W if W else '20000') }}" required min="0">
@@ -70,7 +70,7 @@
       <button type="submit" class="btn btn-primary">Calculate</button>
     </form>
     <div class="mt-4 text-center"> {# Added margin and text centering for the link/button #}
-      <a href="{{ url_for('routes.compare') }}" class="btn btn-secondary">Compare Scenarios</a>
+      <a href="{{ url_for('compare') }}" class="btn btn-secondary">Compare Scenarios</a>
     </div>
   </div>
 {% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -218,7 +218,7 @@
   </div>
   <div class="text-center mt-4"> {# Centering for buttons #}
     <button id="recalculate_button" class="btn btn-primary recalculate-btn" style="margin-top: 30px;">Update Results</button>
-    <a href="{{ url_for('routes.index') }}" class="btn btn-outline-secondary" style="margin-top: 30px;">← Back to Calculator</a>
+    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary" style="margin-top: 30px;">← Back to Calculator</a>
   </div>
 </div>
 {% endblock %}
@@ -350,7 +350,7 @@
             formData.append('D', exportContainer.dataset.d || '0.0');
 
 
-            fetch("{{ url_for('routes.update') }}", { // Use url_for for robustness
+            fetch("{{ url_for('update') }}", { // Use url_for for robustness
                 method: 'POST',
                 body: formData
             })
@@ -432,7 +432,7 @@
                 params.append('i', i_output.value || container.dataset.i || '0');
                 params.append('T', T_output.value || container.dataset.t || '0');
           }
-          exportLink.href = `{{ url_for('routes.export_csv') }}?${params.toString()}`;
+          exportLink.href = `{{ url_for('export_csv') }}?${params.toString()}`;
         }
 
         function updatePage(data, sourceElement = null) {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -33,7 +33,7 @@
   <p class="mt-2"><small>Settings are saved in your browser's local storage.</small></p>
 
   <div class="mt-4">
-    <a href="{{ url_for('routes.index') }}" class="btn btn-outline-secondary">← Back to Calculator</a>
+    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">← Back to Calculator</a>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
I resolved a `werkzeug.routing.exceptions.BuildError` that was caused by incorrect endpoint names in `url_for` calls within your templates. The error typically manifested as "Could not build url for endpoint 'routes.index'. Did you mean 'index' instead?".

Here are the changes I made:
- I removed the erroneous 'routes.' prefix from `url_for` calls in multiple templates, including:
  - `templates/base.html` (navbar links, active link checks)
  - `templates/result.html` ("Back to Calculator" link, JavaScript fetch and export links)
  - `templates/index.html` (form action, "Compare Scenarios" button)
  - `templates/compare.html` (form action, "Back to Calculator" link, JavaScript AJAX call)
  - `templates/settings.html` ("Back to Calculator" link)

This ensures that `url_for` uses the correct endpoint names as registered by the Flask application (e.g., 'index', 'compare', 'settings'), allowing URLs to be built correctly and resolving the runtime error.