### PR TITLE
Fix: Resolve UndefinedError for 'globals' in templates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -38,15 +38,15 @@
       <h4>Period {{ k }}</h4>
       <div class="mb-3">
         <label for="period{{k}}_duration" class="form-label">Period {{ k }} Duration (years):</label>
-        <input type="number" name="period{{k}}_duration" id="period{{k}}_duration" class="form-control" value="{{ request.form.get('period{}_duration'.format(k), globals().get('period{}_duration'.format(k), '')) }}" min="0" step="1">
+        <input type="number" name="period{{k}}_duration" id="period{{k}}_duration" class="form-control" value="{{ request.form.get('period{}_duration'.format(k)) or _context['period{}_duration'.format(k)] }}" min="0" step="1">
       </div>
       <div class="mb-3">
         <label for="period{{k}}_r" class="form-label">Period {{ k }} Return (%):</label>
-        <input type="number" name="period{{k}}_r" id="period{{k}}_r" class="form-control" step="0.1" value="{{ request.form.get('period{}_r'.format(k), globals().get('period{}_r'.format(k), '')) }}" min="-50" max="100">
+        <input type="number" name="period{{k}}_r" id="period{{k}}_r" class="form-control" step="0.1" value="{{ request.form.get('period{}_r'.format(k)) or _context['period{}_r'.format(k)] }}" min="-50" max="100">
       </div>
       <div class="mb-3">
         <label for="period{{k}}_i" class="form-label">Period {{ k }} Inflation (%):</label>
-        <input type="number" name="period{{k}}_i" id="period{{k}}_i" class="form-control" step="0.1" value="{{ request.form.get('period{}_i'.format(k), globals().get('period{}_i'.format(k), '')) }}" min="-50" max="100">
+        <input type="number" name="period{{k}}_i" id="period{{k}}_i" class="form-control" step="0.1" value="{{ request.form.get('period{}_i'.format(k)) or _context['period{}_i'.format(k)] }}" min="-50" max="100">
       </div>
       {% endfor %}
       <hr>


### PR DESCRIPTION
I corrected a `jinja2.exceptions.UndefinedError: 'globals' is undefined` error that occurred in `templates/index.html`. The error was caused by an attempt to use the Python `globals()` function within a Jinja expression to access default form values.

The fix involves:
- Modified `templates/index.html`:
  - In the loop for period inputs (`period<k>_duration`, `period<k>_r`, `period<k>_i`), I changed the `value` attributes.
  - I replaced expressions like `value="{{ request.form.get('key', globals().get('key', '')) }}"` with `value="{{ request.form.get('key') or _context['key'] }}"`.
  - This uses Jinja's `_context` object to correctly and safely access variables passed from the Flask route (e.g., `period1_duration`) when `request.form` does not contain the key.

This ensures that default values for form fields are accessed using standard Jinja mechanisms, resolving the `UndefinedError`.