### PR TITLE
Fix: Correct panel layout in results page

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -41,7 +41,7 @@
   </div>
 
   <div class="container"> {# This was an extra container, can be merged or kept if styling needs it #}
-    <div class="layout-column-group row">
+    <div class="row">
       <!-- Calculation Assumptions -->
       <div class="col-md-12 mb-3">
         <div class="card common-parameters-container collapsible-section">


### PR DESCRIPTION
This commit addresses the issue of panels in results.html (Expense Mode and FIRE Mode) stacking vertically and being too narrow.

The root cause was the `layout-column-group` class being applied to the same `div` as Bootstrap's `row` class. The CSS for `layout-column-group` included `flex-direction: column;` and `max-width: 500px;`, which conflicted with and overrode Bootstrap's intended row behavior.

The fix involves removing the `layout-column-group` class from the affected `div` in `templates/result.html`, leaving only the `row` class. This allows Bootstrap's grid system to correctly manage the layout of the `col-md-6` panels, ensuring they appear side-by-side and utilize the appropriate width.

Table visibility (hidden on screen, visible on export) remains unaffected and correct.