### PR TITLE
Fix: Correct panel layout in results page via CSS override

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -378,6 +378,11 @@ a:hover {
   flex-direction: column;
 }
 
+.layout-column-group.row {
+  flex-direction: row !important;
+  max-width: none !important;
+}
+
 .export-button-container-above-fire {
   /* Behaves like a column item */
   flex: 1;

--- a/templates/result.html
+++ b/templates/result.html
@@ -41,7 +41,7 @@
   </div>
 
   <div class="container"> {# This was an extra container, can be merged or kept if styling needs it #}
-    <div class="row">
+    <div class="layout-column-group row">
       <!-- Calculation Assumptions -->
       <div class="col-md-12 mb-3">
         <div class="card common-parameters-container collapsible-section">


### PR DESCRIPTION
This commit addresses the persistent issue of panels in results.html (Expense Mode and FIRE Mode) stacking vertically and being too narrow.

The previous attempts involved modifying the HTML structure. This attempt reverts the HTML to its state where the containing div has classes "layout-column-group row", and introduces a specific CSS override.

A new rule has been added to `static/css/main.css`:
```css
.layout-column-group.row {
  flex-direction: row !important;
  max-width: none !important;
}
```
This rule specifically targets elements with both `layout-column-group` and `row` classes. It overrides the `flex-direction: column;` and `max-width: 500px;` from the general `.layout-column-group` rule that were causing the layout conflict with Bootstrap's `.row` behavior. The `!important` flag is used to ensure these styles take precedence.

This approach should allow Bootstrap's grid system to correctly manage the layout of the `col-md-6` panels, ensuring they appear side-by-side and utilize the appropriate width, while preserving the original `layout-column-group` styles for other potential uses.

Table visibility (hidden on screen, visible on export) remains unaffected and correct.