### PR TITLE
Feature: Update periodic rate layout on home page to be more compact

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -35,18 +35,19 @@
       <p><small class="form-text text-muted">If any period duration is specified, these periodic rates will override the overall fallback rates above. Unspecified periods will be ignored.</small></p>
 
       {% for k in range(1, 4) %}
-      <h4>Period {{ k }}</h4>
-      <div class="mb-3">
-        <label for="period{{k}}_duration" class="form-label">Period {{ k }} Duration (years):</label>
-        <input type="number" name="period{{k}}_duration" id="period{{k}}_duration" class="form-control" value="{{ request.form.get('period{}_duration'.format(k)) or defaults['period{}_duration'.format(k)] }}" min="0" step="1">
-      </div>
-      <div class="mb-3">
-        <label for="period{{k}}_r" class="form-label">Period {{ k }} Return (%):</label>
-        <input type="number" name="period{{k}}_r" id="period{{k}}_r" class="form-control" step="0.1" value="{{ request.form.get('period{}_r'.format(k)) or defaults['period{}_r'.format(k)] }}" min="-50" max="100">
-      </div>
-      <div class="mb-3">
-        <label for="period{{k}}_i" class="form-label">Period {{ k }} Inflation (%):</label>
-        <input type="number" name="period{{k}}_i" id="period{{k}}_i" class="form-control" step="0.1" value="{{ request.form.get('period{}_i'.format(k)) or defaults['period{}_i'.format(k)] }}" min="-50" max="100">
+      <div class="period-group row gx-2 mb-2">
+        <div class="col">
+          <label for="period{{k}}_duration" class="form-label form-label-sm">P{{k}} Dur.:</label>
+          <input type="number" name="period{{k}}_duration" id="period{{k}}_duration" class="form-control form-control-sm" value="{{ request.form.get('period{}_duration'.format(k)) or defaults['period{}_duration'.format(k)] }}" min="0" step="1" placeholder="Years">
+        </div>
+        <div class="col">
+          <label for="period{{k}}_r" class="form-label form-label-sm">P{{k}} Ret(%):</label>
+          <input type="number" name="period{{k}}_r" id="period{{k}}_r" class="form-control form-control-sm" step="0.1" value="{{ request.form.get('period{}_r'.format(k)) or defaults['period{}_r'.format(k)] }}" min="-50" max="100" placeholder="%">
+        </div>
+        <div class="col">
+          <label for="period{{k}}_i" class="form-label form-label-sm">P{{k}} Inf(%):</label>
+          <input type="number" name="period{{k}}_i" id="period{{k}}_i" class="form-control form-control-sm" step="0.1" value="{{ request.form.get('period{}_i'.format(k)) or defaults['period{}_i'.format(k)] }}" min="-50" max="100" placeholder="%">
+        </div>
       </div>
       {% endfor %}
       <hr>


### PR DESCRIPTION
I modified the periodic rate configuration section in `templates/index.html` to match the compact, row-based layout used on the compare page.

- I replaced the previous stacked layout for period duration, return, and inflation inputs with a Bootstrap `row` containing three `col` elements for each period.
- I utilized `form-control-sm` and `form-label-sm` classes for smaller inputs and labels.
- I adjusted label text to be more concise (e.g., "P1 Dur.:").
- I removed the `<h4>Period X</h4>` subheadings for each period as the new labels incorporate period numbers.

This change significantly reduces the vertical space taken by the periodic rate configuration on the home page, making the form more compact and improving consistency with the compare page.