### PR TITLE
fix: Correct @babel.locale_selector decorator typo in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ register_app_routes(app)
 app.logger.info("Application routes registered.")
 
 # --- Babel Locale Selector ---
-@babel.localeselector
+@babel.locale_selector
 def get_locale_selector():
     app.logger.debug("Attempting to get locale in get_locale_selector.")
     # Use the Accept-Language header to determine the best match.


### PR DESCRIPTION
This commit fixes an `AttributeError: 'Babel' object has no attribute 'localeselector'` that was preventing the application from starting. The decorator has been corrected from `@babel.localeselector` to `@babel.locale_selector`.

For this deployment, `project/routes.py` remains in its minimal state (defining an empty blueprint with no actual routes or complex imports) to isolate the test of this specific fix in `app.py`.

If this deployment is successful, subsequent commits will incrementally restore functionality to `project/routes.py`.