### PR TITLE
fix: Correct url_for calls in templates for blueprint routes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,14 +12,14 @@
   <header class="container mt-3 mb-3 text-center">
     <h1>
       <span class="title-tooltip-container">
-        <a class="text-decoration-none" href="{{ url_for('index') }}">{{ _("FIRE Calculator") }}</a>
+        <a class="text-decoration-none" href="{{ url_for('project.index') }}">{{ _("FIRE Calculator") }}</a>
         <span class="tooltip-text main-title-tooltip">{{ _("Financial Independence, Retire Early: A movement dedicated to a program of extreme savings and investment that aims to allow proponents to retire far earlier than traditional budgets and retirement plans would permit.") }}</span>
       </span>
     </h1>
     <div class="sub-nav">
-      <a href="{{ url_for('index') }}" class="sub-nav-item {% if request.endpoint == 'index' %}active{% endif %}">{{ _("Home") }}</a>
-      <a href="{{ url_for('compare') }}" class="sub-nav-item {% if request.endpoint == 'compare' %}active{% endif %}">{{ _("Compare") }}</a>
-      <a href="{{ url_for('settings') }}" class="sub-nav-item {% if request.endpoint == 'settings' %}active{% endif %}">{{ _("Settings") }}</a>
+      <a href="{{ url_for('project.index') }}" class="sub-nav-item {% if request.endpoint == 'project.index' %}active{% endif %}">{{ _("Home") }}</a>
+      <a href="{{ url_for('project.compare') }}" class="sub-nav-item {% if request.endpoint == 'project.compare' %}active{% endif %}">{{ _("Compare") }}</a>
+      <a href="{{ url_for('project.settings') }}" class="sub-nav-item {% if request.endpoint == 'project.settings' %}active{% endif %}">{{ _("Settings") }}</a>
       <button class="btn btn-sm btn-outline-secondary sub-nav-item" onclick="toggleTheme()">{{ _("Toggle Theme") }}</button>
     </div>
   </header>
@@ -40,8 +40,8 @@
 
   <footer class="container mt-5 py-3 text-center text-muted">
     <p>&copy; {{ _("FIRE Calculator") }} {% block year %}{{ current_year }}{% endblock %} |
-      <a href="{{ url_for('about') }}" class="text-muted">{{ _("About") }}</a> |
-      <a href="{{ url_for('faq') }}" class="text-muted">{{ _("FAQ") }}</a>
+      <a href="{{ url_for('project.about') }}" class="text-muted">{{ _("About") }}</a> |
+      <a href="{{ url_for('project.faq') }}" class="text-muted">{{ _("FAQ") }}</a>
     </p>
   </footer>
 

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -27,7 +27,7 @@
     <select id="loadScenarioSelect" class="form-select" style="width: auto; display: inline-block;" onchange="loadScenario()"></select>
   </div>
 
-  <form method="post" action="{{ url_for('compare') }}" id="compareForm" class="needs-validation" novalidate>
+  <form method="post" action="{{ url_for('project.compare') }}" id="compareForm" class="needs-validation" novalidate>
     <div class="scenario-container">
       {# The scenarios variable is passed from the route #}
       {% for scenario in scenarios %}
@@ -128,7 +128,7 @@
   {% endif %}
 
   <div class="mt-4"> {# Added spacing for back link #}
-    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
+    <a href="{{ url_for('project.index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
   </div>
 </div>
 {% endblock %}
@@ -213,7 +213,7 @@
     function updateComparison() {
       $.ajax({
         type: "POST",
-        url: "{{ url_for('compare') }}", // Use url_for for robustness
+        url: "{{ url_for('project.compare') }}", // Use url_for for robustness
         data: $("#compareForm").serialize(),
         headers: { "X-Requested-With": "XMLHttpRequest" },
         success: function(response) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
     {% if error %}
       <div class="alert alert-danger">{{ error }}</div> {# Error messages from backend are already translated #}
     {% endif %}
-    <form method="post" action="{{ url_for('index') }}" class="needs-validation" novalidate id="calculatorForm">
+    <form method="post" action="{{ url_for('project.index') }}" class="needs-validation" novalidate id="calculatorForm">
       <div class="mb-3">
         <label for="W" class="form-label">{{ _("Annual Expenses (in today's dollars):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Your estimated current annual living expenses.") }}</span></span></label>
         <input type="number" name="W" id="W" class="form-control" value="{{ request.form.get('W', defaults.W) }}" required min="0">
@@ -71,7 +71,7 @@
       <button type="submit" class="btn btn-primary">{{ _("Calculate") }}</button>
     </form>
     <div class="mt-4 text-center"> {# Added margin and text centering for the link/button #}
-      <a href="{{ url_for('compare') }}" class="btn btn-secondary">{{ _("Compare Scenarios") }}</a>
+      <a href="{{ url_for('project.compare') }}" class="btn btn-secondary">{{ _("Compare Scenarios") }}</a>
     </div>
   </div>
 {% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -158,7 +158,7 @@
     </div>
   </div>
   <div class="text-center mt-4"> {# Centering for buttons #}
-    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary" style="margin-top: 30px;">{{ _("← Back to Calculator") }}</a>
+    <a href="{{ url_for('project.index') }}" class="btn btn-outline-secondary" style="margin-top: 30px;">{{ _("← Back to Calculator") }}</a>
   </div>
 </div>
 {% endblock %}
@@ -307,7 +307,7 @@
             formData.append('D', exportContainer.dataset.d || '0.0');
 
 
-            fetch("{{ url_for('update') }}", { // Use url_for for robustness
+            fetch("{{ url_for('project.update') }}", { // Use url_for for robustness
                 method: 'POST',
                 body: formData
             })
@@ -389,7 +389,7 @@
                 params.append('i', i_output.value || container.dataset.i || '0');
                 params.append('T', T_output.value || container.dataset.t || '0');
           }
-          exportLink.href = `{{ url_for('export_csv') }}?${params.toString()}`;
+          exportLink.href = `{{ url_for('project.export_csv') }}?${params.toString()}`;
         }
 
         function updatePage(data, sourceElement = null) {


### PR DESCRIPTION
Updates `url_for()` calls in all relevant templates (`base.html`, `index.html`, `result.html`, `compare.html`) to correctly reference endpoints within the `project_blueprint` by prefixing them with `project.` (e.g., `url_for('project.index')`).

This resolves the `werkzeug.routing.exceptions.BuildError` that occurred when rendering templates that extend `base.html` or directly use `url_for` for these routes.

For this deployment:
- `app.py` has the correct Babel initialization.
- `project/routes.py` has the `settings` route restored, with other routes remaining as minimal stubs.