### PR TITLE
fix: Correct url_for call in settings.html template

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -34,7 +34,7 @@
   <p class="mt-2"><small>{{ _("Settings are saved in your browser's local storage.") }}</small></p>
 
   <div class="mt-4">
-    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
+    <a href="{{ url_for('project.index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Updates the `url_for('index')` call within `templates/settings.html` to `url_for('project.index')` to correctly reference the namespaced endpoint from the `project` blueprint.

This resolves the `werkzeug.routing.exceptions.BuildError` that occurred when rendering the settings page.

For this deployment:
- `app.py` has the correct Babel initialization.
- `project/routes.py` has the `settings` route's logic restored, with other routes remaining as minimal stubs.
- All relevant `url_for` calls in templates should now be correct.