### PR TITLE
fix: Correct url_for calls in about.html and faq.html templates

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -16,7 +16,7 @@
   </ul>
   <p>{{ _("Whether you are just starting to think about financial independence or are well on your way, this calculator aims to provide valuable insights. Remember that all calculations are based on the inputs you provide and are for informational purposes only. Financial planning is complex, and it's recommended to consult with a qualified financial advisor for personalized advice.") }}</p>
   <div class="mt-4">
-    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
+    <a href="{{ url_for('project.index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -60,7 +60,7 @@
     </div>
   </div>
   <div class="mt-4">
-    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
+    <a href="{{ url_for('project.index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Updates `url_for('index')` calls within `templates/about.html` and `templates/faq.html` to `url_for('project.index')` to correctly reference the namespaced endpoint from the `project` blueprint.

This resolves the `werkzeug.routing.exceptions.BuildError` that occurred when rendering these pages.

For this deployment:
- `app.py` has the correct Babel initialization.
- `project/routes.py` has the `settings`, `about`, and `faq` routes' logic restored, with other routes minimal.
- All relevant `url_for` calls in templates should now be correct.