### PR TITLE
To help diagnose the issue, I've temporarily modified line 18 in `tem…

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
       </div>
 
       <div class="mb-3">
-        <label for="r" class="form-label">{{ _("Overall Annual Return") }} (%%) {{ _("(Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected average annual investment return (e.g., 7% for 7). Used if no specific periods are defined.") }}</span></span></label>
+        <label for="r" class="form-label">Overall Annual Return (%%) (Fallback):<span class="info-icon">&#9432;<span class="tooltip-text">Expected average annual investment return (e.g., 7% for 7). Used if no specific periods are defined.</span></span></label>
         <input type="number" name="r" id="r" class="form-control" step="0.1" value="{{ request.form.get('r', defaults.r) }}" min="-50" max="100">
         <small class="form-text text-muted">{{ _("Used if no periodic rates are specified below.") }}</small>
       </div>


### PR DESCRIPTION
…plates/index.html`. Specifically, I've changed the "Overall Annual Return" label and its tooltip to use plain text, removing the internationalization calls from that line.

This change is to see if the persistent `TypeError: float() argument must be a string or a real number, not 'dict'` is directly caused by how the text on this line is being processed for different languages.

Other parts of your application, including other translatable strings in `index.html` and other templates, remain unchanged. `app.py` has the correct internationalization setup, and the `index` route is active.