### PR TITLE
fix: Remove syntax error in project/routes.py

### DIFF
--- a/project/routes.py
+++ b/project/routes.py
@@ -410,5 +410,3 @@ def register_app_routes(app_instance):
     app_instance.logger.info("Attempting to register project_blueprint (with restored routes).")
     app_instance.register_blueprint(project_blueprint)
     app_instance.logger.info("project_blueprint (with restored routes) registered.")
-
-[end of project/routes.py]


### PR DESCRIPTION
This commit removes an erroneous marker line `[end of project/routes.py]` that was accidentally included at the end of the `project/routes.py` file. This line caused a SyntaxError, preventing the application from running.