### PR TITLE
Here's the revised message:

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -230,39 +230,70 @@
           console.log('[CompareDebug] Response combined_withdrawal HTML (first 100 chars):', response.combined_withdrawal ? response.combined_withdrawal.substring(0,100) : 'N/A');
           console.log('[CompareDebug] Response scenarios:', response.scenarios);
 
-          if(response.message && response.message.length > 0) {
-            $("#combinedGraphs").html("");
-            $("#summaryTable").html("");
-            // Display general message (e.g. "No valid scenarios to plot")
-            // This could be shown in a dedicated message area or as an alert
-            // For now, using an alert for general messages.
-            alert(response.message); // Already translated from backend
-          } else if (response.scenarios) {
-            $("#combinedGraphs").html(
-              "<h3>" + _("Combined Portfolio Balance") + "</h3>" +
-              (response.combined_balance || "<p>" + _("No balance graph data.") + "</p>") +
-              "<h3>" + _("Combined Annual Withdrawals") + "</h3>" +
-              (response.combined_withdrawal || "<p>" + _("No withdrawal graph data.") + "</p>")
-            );
+          if (response.message && response.message.length > 0) {
+              $("#combinedGraphs").html(""); // Clear graphs
+              $("#summaryTable").html("");   // Clear table
+              alert(response.message); // Already translated from backend
+              // Potentially clear individual scenario results if a global message indicates total failure
+               $(".scenario .result-section").remove();
+               $(".scenario .alert.alert-warning.error-message").remove();
+          } else if (response.scenarios && response.scenarios.length > 0) {
+              $("#combinedGraphs").html(''); // Clear previous graphs before adding new ones
+              try {
+                  const balanceContent = "<h3>" + _("Combined Portfolio Balance") + "</h3>" +
+                                     (response.combined_balance || "<p>" + _("No balance graph data.") + "</p>");
+                  $("#combinedGraphs").append(balanceContent);
+                  console.log('[CompareDebug] Updated combined balance graph section.');
+              } catch (e) {
+                  console.error('[CompareDebug] Error updating balance graph:', e);
+                  $("#combinedGraphs").append("<p class='text-danger'>" + _("Error displaying balance graph.") + "</p>");
+              }
+
+              try {
+                  const withdrawalContent = "<h3>" + _("Combined Annual Withdrawals") + "</h3>" +
+                                        (response.combined_withdrawal || "<p>" + _("No withdrawal graph data.") + "</p>");
+                  $("#combinedGraphs").append(withdrawalContent);
+                  console.log('[CompareDebug] Updated combined withdrawal graph section.');
+              } catch (e) {
+                  console.error('[CompareDebug] Error updating withdrawal graph:', e);
+                  $("#combinedGraphs").append("<p class='text-danger'>" + _("Error displaying withdrawal graph.") + "</p>");
+              }
           } else {
-             $("#combinedGraphs").html("<p>" + _("Error: Received unexpected response from server.") + "</p>");
-             $("#summaryTable").html("");
+              console.log('[CompareDebug] No message and no scenarios in response. Clearing graphs/table.');
+              $("#combinedGraphs").html("<p>" + _("No comparison data available or an unexpected error occurred.") + "</p>");
+              $("#summaryTable").html("");
           }
 
-          // Always update scenarios display (errors, results) and summary table
-          if(response.scenarios && Array.isArray(response.scenarios)){
-              updateSummaryTable(response.scenarios);
-              response.scenarios.forEach(function(sc, index) {
-                  var scenarioDiv = $("#scenario" + (sc.n || index + 1)); // Use sc.n if available
-                  scenarioDiv.find(".result-section").remove(); // Clear old results
-                  scenarioDiv.find(".error-message").remove(); // Clear old errors
-                  if(sc.error){
-                      scenarioDiv.append('<div class="alert alert-warning mt-2 p-2 error-message">' + sc.error + '</div>'); // Already translated
-                  } else if (sc.fire_number_display && sc.fire_number_display !== "N/A") {
-                      var resultHtml = '<div class="result-section mt-2"><p><strong>' + _("FIRE Number:") + '</strong> ' + sc.fire_number_display + '</p></div>';
-                      scenarioDiv.append(resultHtml);
-                  }
-              });
+          // Scenario details and summary table updates should always try to run if response.scenarios exists
+          if (response.scenarios && Array.isArray(response.scenarios)) {
+              try {
+                  updateSummaryTable(response.scenarios);
+                  console.log('[CompareDebug] Summary table update attempted.');
+              } catch (e) {
+                  console.error('[CompareDebug] Error calling updateSummaryTable:', e);
+                  $("#summaryTable").html("<p class='text-danger'>" + _("Error displaying summary table.") + "</p>");
+              }
+
+              try {
+                  response.scenarios.forEach(function(sc, index) {
+                      var scenarioDiv = $("#scenario" + (sc.n || index + 1));
+                      if (scenarioDiv.length === 0) {
+                          console.warn('[CompareDebug] Scenario div not found for scenario number:', (sc.n || index + 1));
+                          return;
+                      }
+                      scenarioDiv.find(".result-section").remove();
+                      scenarioDiv.find(".alert.alert-warning.error-message").remove(); // More specific selector
+                      if(sc.error){
+                          scenarioDiv.append('<div class="alert alert-warning mt-2 p-2 error-message">' + sc.error + '</div>');
+                      } else if (sc.fire_number_display && sc.fire_number_display !== "N/A") {
+                          var resultHtml = '<div class="result-section mt-2"><p><strong>' + _("FIRE Number:") + '</strong> ' + sc.fire_number_display + '</p></div>';
+                          scenarioDiv.append(resultHtml);
+                      }
+                  });
+                  console.log('[CompareDebug] Individual scenario updates attempted.');
+              } catch (e) {
+                  console.error('[CompareDebug] Error updating individual scenarios:', e);
+              }
           }
         },
         error: function(xhr, status, error) {

--- a/templates/result.html
+++ b/templates/result.html
@@ -500,19 +500,19 @@
                 const parsedWForLog = W_output_left ? parseFormattedNumberFromInput(W_output_left.value) : 'N/A';
                 console.log('[CompareLinkDebug] Parsed W for params:', parsedWForLog);
                 if (W_output_left) {
-                    params.append('W', parsedWForLog || '0');
+                    params.append('W', String(parsedWForLog || '0'));
                 } else {
-                    params.append('W', container.dataset.w || '0');
+                    params.append('W', String(container.dataset.w || '0'));
                 }
 
                 const dValForLog = container ? container.dataset.d : 'container not found';
                 console.log('[CompareLinkDebug] container.dataset.d:', dValForLog);
-                params.append('D', dValForLog || '0.0');
+                params.append('D', String(dValForLog || '0.0'));
 
                 const withdrawal_time_selected = document.querySelector('input[name="withdrawal_time"]:checked');
                 const withdrawalTimeValForLog = withdrawal_time_selected ? withdrawal_time_selected.value : (container ? container.dataset.withdrawalTime : 'withdrawal_time_selected and container.dataset.withdrawalTime not found');
                 console.log('[CompareLinkDebug] withdrawal_time value or fallback:', withdrawalTimeValForLog);
-                params.append('withdrawal_time', withdrawalTimeValForLog || '{{ TIME_END_const }}');
+                params.append('withdrawal_time', String(withdrawalTimeValForLog || '{{ TIME_END_const }}'));
 
                 // Handle single vs multi-period data
                 const ratesPeriodsJson = container.dataset.ratesPeriods;
@@ -531,23 +531,23 @@
                 if (ratesPeriods && Array.isArray(ratesPeriods) && ratesPeriods.length > 0) {
                     console.log('[CompareLinkDebug] Using multi-period data for link.');
                     ratesPeriods.forEach((period, index) => {
-                        params.append(`period${index+1}_duration`, period.duration);
-                        params.append(`period${index+1}_r`, period.r * 100);
-                        params.append(`period${index+1}_i`, period.i * 100);
+                        params.append(`period${index+1}_duration`, String(period.duration));
+                        params.append(`period${index+1}_r`, String(period.r * 100));
+                        params.append(`period${index+1}_i`, String(period.i * 100));
                     });
                 } else {
                     console.log('[CompareLinkDebug] Using single-period data for link or fallback.');
                     const rValForLog = r_output ? r_output.value : (container ? container.dataset.r : 'r_output and container.dataset.r not found');
                     console.log('[CompareLinkDebug] r_output value or fallback:', rValForLog);
-                    if (r_output) params.append('r', r_output.value); else params.append('r', container.dataset.r || '0');
+                    if (r_output) params.append('r', String(r_output.value)); else params.append('r', String(container.dataset.r || '0'));
 
                     const iValForLog = i_output ? i_output.value : (container ? container.dataset.i : 'i_output and container.dataset.i not found');
                     console.log('[CompareLinkDebug] i_output value or fallback:', iValForLog);
-                    if (i_output) params.append('i', i_output.value); else params.append('i', container.dataset.i || '0');
+                    if (i_output) params.append('i', String(i_output.value)); else params.append('i', String(container.dataset.i || '0'));
 
                     const tValForLog = T_output ? T_output.value : (container ? container.dataset.t : 'T_output and container.dataset.t not found');
                     console.log('[CompareLinkDebug] T_output value or fallback:', tValForLog);
-                    if (T_output) params.append('T', T_output.value); else params.append('T', container.dataset.t || '0');
+                    if (T_output) params.append('T', String(T_output.value)); else params.append('T', String(container.dataset.t || '0'));
                 }
 
                 console.log('[CompareLinkDebug] Constructed query params:', params.toString());


### PR DESCRIPTION
fix: Further robustify compare functionality and link

This commit provides additional fixes and robustness improvements for the "Compare Scenarios" features:

1.  **Result Page -> Compare Page Link (`result.html`):**
    *   In the `updateCompareScenariosLink` JavaScript function, all values
      appended to `URLSearchParams` are now explicitly cast to strings.
      This is a defensive measure to ensure consistent behavior in URL
      construction, further aiding the fix for parameters not reaching
      the `/compare` GET route. Logging remains in place.

2.  **Compare Page AJAX Data Display (`compare.html`):**
    *   The `success` callback within the `updateComparison` JavaScript
      function has been significantly refactored. DOM updates for
      combined graphs, the summary table, and individual scenario
      details are now wrapped in individual try-catch blocks.
    *   This prevents an error in one part of the DOM update (e.g.,
      rendering one graph) from halting other updates (e.g., table or
      other scenario details).
    *   Conditional logic for displaying content based on the AJAX
      response (e.g., `response.message`, `response.scenarios`) has
      been clarified. Logging remains in place.

3.  **Primary Result Display (`result.html`):**
    *   Re-confirmed that the primary result display correctly shows
      relevant "Input Annual Expenses" when the "Calculated FIRE Number"
      is the main displayed result.

These changes aim to resolve observed issues with data not being passed to the compare page, and graphs/tables not displaying on the compare page itself. The extensive logging added in previous commits is retained to help diagnose any further subtle issues.