### PR TITLE
Here's the rewritten message:

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -240,27 +240,27 @@
           } else if (response.scenarios && response.scenarios.length > 0) {
               $("#combinedGraphs").html(''); // Clear previous graphs before adding new ones
               try {
-                  const balanceContent = "<h3>" + _("Combined Portfolio Balance") + "</h3>" +
-                                     (response.combined_balance || "<p>" + _("No balance graph data.") + "</p>");
+                  const balanceContent = "<h3>Combined Portfolio Balance</h3>" +
+                                     (response.combined_balance || "<p>No balance graph data.</p>");
                   $("#combinedGraphs").append(balanceContent);
                   console.log('[CompareDebug] Updated combined balance graph section.');
               } catch (e) {
                   console.error('[CompareDebug] Error updating balance graph:', e);
-                  $("#combinedGraphs").append("<p class='text-danger'>" + _("Error displaying balance graph.") + "</p>");
+                  $("#combinedGraphs").append("<p class='text-danger'>Error displaying balance graph.</p>");
               }
 
               try {
-                  const withdrawalContent = "<h3>" + _("Combined Annual Withdrawals") + "</h3>" +
-                                        (response.combined_withdrawal || "<p>" + _("No withdrawal graph data.") + "</p>");
+                  const withdrawalContent = "<h3>Combined Annual Withdrawals</h3>" +
+                                        (response.combined_withdrawal || "<p>No withdrawal graph data.</p>");
                   $("#combinedGraphs").append(withdrawalContent);
                   console.log('[CompareDebug] Updated combined withdrawal graph section.');
               } catch (e) {
                   console.error('[CompareDebug] Error updating withdrawal graph:', e);
-                  $("#combinedGraphs").append("<p class='text-danger'>" + _("Error displaying withdrawal graph.") + "</p>");
+                  $("#combinedGraphs").append("<p class='text-danger'>Error displaying withdrawal graph.</p>");
               }
           } else {
               console.log('[CompareDebug] No message and no scenarios in response. Clearing graphs/table.');
-              $("#combinedGraphs").html("<p>" + _("No comparison data available or an unexpected error occurred.") + "</p>");
+              $("#combinedGraphs").html("<p>No comparison data available or an unexpected error occurred.</p>");
               $("#summaryTable").html("");
           }
 
@@ -271,7 +271,7 @@
                   console.log('[CompareDebug] Summary table update attempted.');
               } catch (e) {
                   console.error('[CompareDebug] Error calling updateSummaryTable:', e);
-                  $("#summaryTable").html("<p class='text-danger'>" + _("Error displaying summary table.") + "</p>");
+                  $("#summaryTable").html("<p class='text-danger'>Error displaying summary table.</p>");
               }
 
               try {
@@ -286,7 +286,7 @@
                       if(sc.error){
                           scenarioDiv.append('<div class="alert alert-warning mt-2 p-2 error-message">' + sc.error + '</div>');
                       } else if (sc.fire_number_display && sc.fire_number_display !== "N/A") {
-                          var resultHtml = '<div class="result-section mt-2"><p><strong>' + _("FIRE Number:") + '</strong> ' + sc.fire_number_display + '</p></div>';
+                          var resultHtml = '<div class="result-section mt-2"><p><strong>FIRE Number:</strong> ' + sc.fire_number_display + '</p></div>';
                           scenarioDiv.append(resultHtml);
                       }
                   });
@@ -307,18 +307,18 @@
     
     function updateSummaryTable(scenarios) {
       console.log('[CompareDebug] updateSummaryTable() called with scenarios:', scenarios);
-      var html = "<table class='table table-striped table-hover'><thead><tr><th>#</th><th>" + _("W") + "</th><th>" + _("Rates & Dur.") + "</th><th>" + _("Timing") + "</th><th>" + _("FIRE #") + "</th><th>" + _("Error") + "</th></tr></thead><tbody>";
+      var html = "<table class='table table-striped table-hover'><thead><tr><th>#</th><th>W</th><th>Rates & Dur.</th><th>Timing</th><th>FIRE #</th><th>Error</th></tr></thead><tbody>";
       scenarios.forEach(function(sc) {
         let rates_display = "N/A";
         if (sc.rates_periods_data && sc.rates_periods_data.length > 0) {
             if (sc.rates_periods_data.length === 1) {
                 let p = sc.rates_periods_data[0];
-                rates_display = _("R:") + ` ${(p.r * 100).toFixed(1)}%, ` + _("I:") + ` ${(p.i * 100).toFixed(1)}%, ` + _("T:") + ` ${p.duration}y`;
+                rates_display = "R:" + ` ${(p.r * 100).toFixed(1)}%, ` + "I:" + ` ${(p.i * 100).toFixed(1)}%, ` + "T:" + ` ${p.duration}y`;
             } else {
-                rates_display = sc.rates_periods_data.map(p => `(` + _("R:") + `${(p.r*100).toFixed(1)}% ` + _("I:") + `${(p.i*100).toFixed(1)}% ` + _("D:") + `${p.duration}y)`).join('<br>');
+                rates_display = sc.rates_periods_data.map(p => `(R:${(p.r*100).toFixed(1)}% I:${(p.i*100).toFixed(1)}% D:${p.duration}y)`).join('<br>');
             }
         } else { // Fallback if rates_periods_data not directly in scenario object, use form values
-            rates_display = _("R:") + ` ${sc.r_form}%, ` + _("I:") + ` ${sc.i_form}%, ` + _("T:") + ` ${sc.T_form}y`;
+            rates_display = "R:" + ` ${sc.r_form}%, ` + "I:" + ` ${sc.i_form}%, ` + "T:" + ` ${sc.T_form}y`;
         }
 
         html += "<tr><td>" + sc.n + "</td>" +

--- a/templates/result.html
+++ b/templates/result.html
@@ -494,34 +494,43 @@
 
                 const params = new URLSearchParams();
 
-                // Get W, D, withdrawal_time
-                const wValForLog = W_output_left ? W_output_left.value : 'W_output_left not found';
-                console.log('[CompareLinkDebug] W_output_left value:', wValForLog);
-                const parsedWForLog = W_output_left ? parseFormattedNumberFromInput(W_output_left.value) : 'N/A';
-                console.log('[CompareLinkDebug] Parsed W for params:', parsedWForLog);
-                if (W_output_left) {
-                    params.append('W', String(parsedWForLog || '0'));
-                } else {
-                    params.append('W', String(container.dataset.w || '0'));
+                // Parameter W
+                let wVal = '0';
+                if (W_output_left && W_output_left.value && W_output_left.value.trim() !== '' && W_output_left.value.toUpperCase() !== _('N/A').toUpperCase()) {
+                    wVal = String(parseFormattedNumberFromInput(W_output_left.value));
+                } else if (container && container.dataset.w) {
+                    wVal = String(container.dataset.w);
                 }
+                params.append('W', wVal);
+                console.log('[CompareLinkDebug] Appending W:', wVal);
 
-                const dValForLog = container ? container.dataset.d : 'container not found';
-                console.log('[CompareLinkDebug] container.dataset.d:', dValForLog);
-                params.append('D', String(dValForLog || '0.0'));
+                // Parameter D
+                let dVal = '0.0';
+                if (container && container.dataset.d) {
+                    dVal = String(container.dataset.d);
+                }
+                params.append('D', dVal);
+                console.log('[CompareLinkDebug] Appending D:', dVal);
 
+                // Parameter withdrawal_time
+                let wtVal = '{{ TIME_END_const }}';
                 const withdrawal_time_selected = document.querySelector('input[name="withdrawal_time"]:checked');
-                const withdrawalTimeValForLog = withdrawal_time_selected ? withdrawal_time_selected.value : (container ? container.dataset.withdrawalTime : 'withdrawal_time_selected and container.dataset.withdrawalTime not found');
-                console.log('[CompareLinkDebug] withdrawal_time value or fallback:', withdrawalTimeValForLog);
-                params.append('withdrawal_time', String(withdrawalTimeValForLog || '{{ TIME_END_const }}'));
+                if (withdrawal_time_selected && withdrawal_time_selected.value) {
+                    wtVal = String(withdrawal_time_selected.value);
+                } else if (container && container.dataset.withdrawalTime) {
+                    wtVal = String(container.dataset.withdrawalTime);
+                }
+                params.append('withdrawal_time', wtVal);
+                console.log('[CompareLinkDebug] Appending withdrawal_time:', wtVal);
 
-                // Handle single vs multi-period data
+                // Multi-period vs Single-period data
+                let periodParamsAdded = false;
                 const ratesPeriodsJson = container.dataset.ratesPeriods;
-                console.log('[CompareLinkDebug] Raw ratesPeriodsJson:', ratesPeriodsJson);
+                console.log('[CompareLinkDebug] Raw ratesPeriodsJson for link:', ratesPeriodsJson);
                 let ratesPeriods = null;
                 if (ratesPeriodsJson && ratesPeriodsJson !== "null" && ratesPeriodsJson.trim() !== "") {
                     try {
                         ratesPeriods = JSON.parse(ratesPeriodsJson);
-                        console.log('[CompareLinkDebug] Parsed ratesPeriods:', ratesPeriods);
                     } catch(e) {
                         console.error("[CompareLinkDebug] Error parsing rates_periods_info_json for compare link: ", e, "JSON string was:", ratesPeriodsJson);
                         ratesPeriods = null;
@@ -529,30 +538,40 @@
                 }
 
                 if (ratesPeriods && Array.isArray(ratesPeriods) && ratesPeriods.length > 0) {
-                    console.log('[CompareLinkDebug] Using multi-period data for link.');
+                    console.log('[CompareLinkDebug] Appending multi-period data:', ratesPeriods);
                     ratesPeriods.forEach((period, index) => {
                         params.append(`period${index+1}_duration`, String(period.duration));
                         params.append(`period${index+1}_r`, String(period.r * 100));
                         params.append(`period${index+1}_i`, String(period.i * 100));
                     });
+                    periodParamsAdded = true;
                 } else {
-                    console.log('[CompareLinkDebug] Using single-period data for link or fallback.');
-                    const rValForLog = r_output ? r_output.value : (container ? container.dataset.r : 'r_output and container.dataset.r not found');
-                    console.log('[CompareLinkDebug] r_output value or fallback:', rValForLog);
-                    if (r_output) params.append('r', String(r_output.value)); else params.append('r', String(container.dataset.r || '0'));
-
-                    const iValForLog = i_output ? i_output.value : (container ? container.dataset.i : 'i_output and container.dataset.i not found');
-                    console.log('[CompareLinkDebug] i_output value or fallback:', iValForLog);
-                    if (i_output) params.append('i', String(i_output.value)); else params.append('i', String(container.dataset.i || '0'));
-
-                    const tValForLog = T_output ? T_output.value : (container ? container.dataset.t : 'T_output and container.dataset.t not found');
-                    console.log('[CompareLinkDebug] T_output value or fallback:', tValForLog);
-                    if (T_output) params.append('T', String(T_output.value)); else params.append('T', String(container.dataset.t || '0'));
+                     console.log('[CompareLinkDebug] No valid multi-period data found or error in parsing.');
                 }
 
-                console.log('[CompareLinkDebug] Constructed query params:', params.toString());
-                compareLink.href = `{{ url_for('project.compare') }}?${params.toString()}`;
-                console.log('[CompareLinkDebug] Final compareLink.href:', compareLink.href);
+                if (!periodParamsAdded) {
+                    let rVal = '0';
+                    if (r_output && r_output.value) { rVal = String(r_output.value); } else if (container && container.dataset.r) { rVal = String(container.dataset.r); }
+                    params.append('r', rVal);
+                    console.log('[CompareLinkDebug] Appending single r:', rVal);
+
+                    let iVal = '0';
+                    if (i_output && i_output.value) { iVal = String(i_output.value); } else if (container && container.dataset.i) { iVal = String(container.dataset.i); }
+                    params.append('i', iVal);
+                    console.log('[CompareLinkDebug] Appending single i:', iVal);
+
+                    let tVal = '0';
+                    if (T_output && T_output.value) { tVal = String(T_output.value); } else if (container && container.dataset.t) { tVal = String(container.dataset.t); }
+                    params.append('T', tVal);
+                    console.log('[CompareLinkDebug] Appending single T:', tVal);
+                }
+
+                const queryString = params.toString();
+                console.log('[CompareLinkDebug] Final query string:', queryString);
+                if (compareLink) {
+                    compareLink.href = `{{ url_for('project.compare') }}?${queryString}`;
+                    console.log('[CompareLinkDebug] Set compareLink.href to:', compareLink.href);
+                }
 
             } catch (e) {
                 console.error("[CompareLinkDebug] Error updating compare scenarios link:", e);


### PR DESCRIPTION
fix: Resolve display issues on results and compare pages

This commit addresses several outstanding issues:

1.  **Ensure 'Input Annual Expenses' Displays on Result Page**:
    *   I modified `project/routes.py` in the `index` route's POST handler
      to explicitly and correctly populate `p_input_w` (and `p_input_p`)
      in the `template_context`. This ensures that when "Your Calculated
      FIRE Number" is the primary result, the corresponding "Input Annual
      Expenses" value is displayed in the "Calculation based on:" section.

2.  **Fix Data Passing for 'Compare with other scenarios' Link**:
    *   I further refined the `updateCompareScenariosLink` JavaScript function
      in `templates/result.html` with aggressive default string values for
      all parameters (`W`, `D`, `withdrawal_time`, `r`, `i`, `T`, and
      multi-period data). All parameters are also explicitly cast to
      String before being appended to `URLSearchParams`. This should
      resolve the issue of no arguments reaching the `/compare` GET route.

3.  **Enable Graph/Table Display on Compare Page (Diagnostic Fix)**:
    *   I temporarily replaced `_()` gettext alias calls with static English
      strings for all dynamically constructed HTML content within the
      AJAX `success` callback and `updateSummaryTable` function in
      `templates/compare.html`. This diagnostic step has enabled the
      display of graphs and tables, indicating a potential issue with
      the `_()` function's behavior or availability in that asynchronous
      JavaScript context. A future task may be needed to implement robust
      localization for these dynamic JS-generated strings if static English
      is not sufficient.

Extensive logging added in previous commits remains for continued monitoring.