### PR TITLE
fix: Resolve ReferenceError in result.html JS and improve links

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -348,14 +348,14 @@
             .then(data => {
                 if (data.error) {
                     console.error('Error from server:', data.error);
-                    alert(_('Error updating calculations: ') + data.error); // data.error should be pre-translated
+                    alert('Error updating calculations: ' + data.error); // data.error should be pre-translated
                     return;
                 }
                 updatePage(data, sourceElement);
             })
             .catch(error => {
                 console.error('Error fetching/processing update:', error);
-                alert(_('Could not update calculations. See console for details.'));
+                alert('Could not update calculations. See console for details.');
                 if (loadingIndicator) loadingIndicator.style.display = 'none';
             });
         }
@@ -457,7 +457,7 @@
                     P_slider_right.value = Math.min(parseFloat(P_slider_right.max), Math.max(parseFloat(P_slider_right.min), numeric_P || 0));
                     P_output_right.value = formatNumberForDisplay(P_slider_right.value, 0);
                 } else {
-                    P_output_right.value = _("N/A");
+                    P_output_right.value = "N/A";
                     P_slider_right.value = P_slider_right.min; // Or some other default like 0
                 }
             }
@@ -469,7 +469,7 @@
                     W_slider_left.value = Math.min(parseFloat(W_slider_left.max), Math.max(parseFloat(W_slider_left.min), numeric_W || 0));
                     W_output_left.value = formatNumberForDisplay(W_slider_left.value, 0);
                 } else {
-                    W_output_left.value = _("N/A");
+                    W_output_left.value = "N/A";
                     W_slider_left.value = W_slider_left.min; // Or some other default like 0
                 }
             }
@@ -496,7 +496,7 @@
 
                 // Parameter W
                 let wVal = '0';
-                if (W_output_left && W_output_left.value && W_output_left.value.trim() !== '' && W_output_left.value.toUpperCase() !== _('N/A').toUpperCase()) {
+                if (W_output_left && W_output_left.value && W_output_left.value.trim() !== '' && W_output_left.value.toUpperCase() !== "N/A".toUpperCase()) {
                     wVal = String(parseFormattedNumberFromInput(W_output_left.value));
                 } else if (container && container.dataset.w) { // Fallback to dataset if input is empty/invalid
                     wVal = String(container.dataset.w);
@@ -595,10 +595,11 @@
                 // Check if the initial value (from Jinja) is "N/A"
                 // The P_output_right.value is already set by Jinja template.
                 // We need to ensure the slider reflects this initial state if it's "N/A".
-                if (P_output_right.value.toUpperCase() === _("N/A").toUpperCase()) {
+                if (P_output_right.value.toUpperCase() === "N/A".toUpperCase()) {
                     // P_slider_right.value is set by Jinja to '0' if expense_P_input_val is 'N/A'.
                     // This is acceptable, or could be P_slider_right.min.
                     // The main thing is P_output_right displays "N/A".
+                     P_output_right.value = "N/A"; // Ensure it's "N/A" if it was _("N/A")
                 } else {
                     // If not "N/A", format the numeric value from slider (or output initial value if preferred)
                      P_output_right.value = formatNumberForDisplay(P_slider_right.value,0);


### PR DESCRIPTION
This commit addresses critical JavaScript errors on result.html and further robustifies link functionalities.

1.  **Resolve `ReferenceError: _ is not defined` on `result.html`**:
    *   I removed all client-side usages of the `_()` gettext alias
      within the JavaScript in `templates/result.html`. Calls like
      `_("N/A")` and translatable alert messages were replaced with
      static English strings.
    *   This error was halting JavaScript execution, preventing functions
      like `initializeFormValues` and `updateCompareScenariosLink`
      from running correctly. Resolving this is expected to fix the
      "Compare with other scenarios" link's failure to navigate and
      pass data.

2.  **Maintained Previous Fixes**:
    *   The fix ensuring "Input Annual Expenses" (or "Input Target
      Portfolio") displays correctly in the primary result panel on
      `result.html` (by correcting Jinja conditions) is included.
    *   The diagnostic fix for `compare.html` (static English strings
      in its AJAX success handler to enable graph/table display)
      is maintained.
    *   Extensive client-side and server-side logging for debugging
      linking and compare page functionality remains in place.

This commit should significantly improve the stability and functionality of the result and compare pages.