### PR TITLE
feat: Implement multi-step FIRE wizard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,14 @@
 import os
 import logging # Make sure logging is imported
 from flask import Flask, request # request for get_locale_selector
+from flask_wtf.csrf import CSRFProtect
 from flask_babel import Babel, get_locale as flask_babel_get_locale
 from babel.numbers import format_currency
 
 # Create the Flask app instance
 app = Flask(__name__)
 app.testing = True # Ensure testing mode is enabled when app is imported
+csrf = CSRFProtect(app)
 
 # Basic app logging
 if not app.debug:
@@ -54,8 +56,11 @@ app.config['DEBUG'] = os.environ.get('FLASK_DEBUG', 'False').lower() == 'true'
 
 # --- Register Routes ---
 from project.routes import register_app_routes
+from project.wizard_routes import wizard_bp # <--- ADD THIS IMPORT
+
 register_app_routes(app)
-app.logger.info("Application routes registered.")
+app.register_blueprint(wizard_bp) # <--- ADD THIS LINE TO REGISTER THE BLUEPRINT
+app.logger.info("Application routes and wizard blueprint registered.") # Update log message
 
 # Make format_currency, get_locale, and DEFAULT_CURRENCY available in Jinja templates
 app.jinja_env.globals['format_currency'] = format_currency

--- a/project/forms.py
+++ b/project/forms.py
@@ -1,0 +1,45 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, FloatField, IntegerField, FieldList, FormField, SubmitField, TextAreaField
+from wtforms.validators import DataRequired, NumberRange, Optional
+
+class PeriodRateForm(FlaskForm):
+    '''Sub-form for individual period rates.'''
+    years = IntegerField('Years in Period', validators=[DataRequired(), NumberRange(min=1)])
+    rate = FloatField('Annual Rate (%)', validators=[DataRequired(), NumberRange(min=-100, max=100)])
+
+class OneOffEntryForm(FlaskForm):
+    '''Sub-form for individual one-off entries (expenses or incomes).'''
+    year = IntegerField('Year', validators=[DataRequired(), NumberRange(min=0)]) # Assuming year is relative to start or absolute
+    amount = FloatField('Amount', validators=[DataRequired(), NumberRange(min=0)])
+    description = StringField('Description', validators=[Optional()])
+
+class ExpensesForm(FlaskForm):
+    '''Form for capturing all annual expenses.'''
+    annual_expenses = FloatField('Total Current Annual Expenses', validators=[DataRequired(), NumberRange(min=0)])
+    housing = FloatField('Housing (e.g., rent/mortgage, property tax, insurance)', validators=[DataRequired(), NumberRange(min=0)])
+    food = FloatField('Food (groceries, dining out)', validators=[DataRequired(), NumberRange(min=0)])
+    transportation = FloatField('Transportation (car payments, fuel, public transport, maintenance)', validators=[DataRequired(), NumberRange(min=0)])
+    utilities = FloatField('Utilities (electricity, water, gas, internet, phone)', validators=[DataRequired(), NumberRange(min=0)])
+    personal_care = FloatField('Personal Care (haircuts, toiletries, gym)', validators=[DataRequired(), NumberRange(min=0)])
+    entertainment = FloatField('Entertainment (hobbies, subscriptions, travel)', validators=[DataRequired(), NumberRange(min=0)])
+    healthcare = FloatField('Healthcare (insurance premiums, medical expenses)', validators=[DataRequired(), NumberRange(min=0)])
+    other_expenses = FloatField('Other Miscellaneous Expenses', validators=[DataRequired(), NumberRange(min=0)])
+    submit = SubmitField('Next: Rates')
+
+class RatesForm(FlaskForm):
+    '''Form for capturing investment return rates and inflation.'''
+    return_rate = FloatField('Overall Portfolio Return Rate (%, nominal)', validators=[DataRequired(), NumberRange(min=-50, max=100)])
+    inflation_rate = FloatField('Assumed Annual Inflation Rate (%)', validators=[DataRequired(), NumberRange(min=-10, max=50)])
+    period_rates = FieldList(FormField(PeriodRateForm), min_entries=0)
+    # It might be good to have a button to dynamically add more period_rates in the template
+    submit_add_period = SubmitField('Add Period Rate') # For dynamically adding more periods
+    submit = SubmitField('Next: One-Offs')
+
+class OneOffsForm(FlaskForm):
+    '''Form for capturing large one-off expenses and incomes.'''
+    large_expenses = FieldList(FormField(OneOffEntryForm), min_entries=0)
+    large_incomes = FieldList(FormField(OneOffEntryForm), min_entries=0)
+    # Buttons to dynamically add more entries in the template
+    submit_add_expense = SubmitField('Add One-Off Expense')
+    submit_add_income = SubmitField('Add One-Off Income')
+    submit = SubmitField('Next: Summary')

--- a/project/wizard_routes.py
+++ b/project/wizard_routes.py
@@ -1,0 +1,85 @@
+from flask import Blueprint, render_template, redirect, url_for, session, request
+from project.forms import ExpensesForm, RatesForm, OneOffsForm # Assuming forms are in project.forms
+
+wizard_bp = Blueprint('wizard_bp', __name__, template_folder='../templates')
+
+@wizard_bp.route('/wizard/expenses', methods=['GET', 'POST'])
+def wizard_expenses_step():
+    form = ExpensesForm(request.form if request.method == 'POST' else None)
+    if form.validate_on_submit():
+        session['wizard_expenses'] = form.data
+        return redirect(url_for('wizard_bp.wizard_rates_step'))
+    # Pre-fill form if data already in session (e.g., user went back)
+    elif request.method == 'GET' and 'wizard_expenses' in session:
+        form = ExpensesForm(data=session['wizard_expenses'])
+    return render_template('wizard_expenses.html', form=form, title='Step 1: Your Expenses')
+
+@wizard_bp.route('/wizard/rates', methods=['GET', 'POST'])
+def wizard_rates_step():
+    # Ensure previous step is done, or redirect back
+    if 'wizard_expenses' not in session:
+        return redirect(url_for('wizard_bp.wizard_expenses_step'))
+
+    form = RatesForm(request.form if request.method == 'POST' else None)
+    if form.validate_on_submit():
+        # Handle dynamic addition of period rates if those buttons were pressed
+        if form.submit_add_period.data:
+            form.period_rates.append_entry()
+            return render_template('wizard_rates.html', form=form, title='Step 2: Rates & Inflation')
+
+        session['wizard_rates'] = form.data
+        return redirect(url_for('wizard_bp.wizard_one_offs_step'))
+    elif request.method == 'GET' and 'wizard_rates' in session:
+        form = RatesForm(data=session['wizard_rates'])
+    return render_template('wizard_rates.html', form=form, title='Step 2: Rates & Inflation')
+
+@wizard_bp.route('/wizard/one_offs', methods=['GET', 'POST'])
+def wizard_one_offs_step():
+    # Ensure previous step is done
+    if 'wizard_rates' not in session:
+        return redirect(url_for('wizard_bp.wizard_rates_step'))
+
+    form = OneOffsForm(request.form if request.method == 'POST' else None)
+    if form.validate_on_submit():
+        # Handle dynamic additions for expenses/incomes
+        if form.submit_add_expense.data:
+            form.large_expenses.append_entry()
+            return render_template('wizard_one_offs.html', form=form, title='Step 3: One-Off Events')
+        elif form.submit_add_income.data:
+            form.large_incomes.append_entry()
+            return render_template('wizard_one_offs.html', form=form, title='Step 3: One-Off Events')
+
+        session['wizard_one_offs'] = form.data
+        return redirect(url_for('wizard_bp.wizard_summary_step')) # Assuming summary step is next
+    elif request.method == 'GET' and 'wizard_one_offs' in session:
+        form = OneOffsForm(data=session['wizard_one_offs'])
+    return render_template('wizard_one_offs.html', form=form, title='Step 3: One-Off Events')
+
+
+@wizard_bp.route('/wizard/summary', methods=['GET'])
+def wizard_summary_step():
+    # Ensure all previous steps are done, or redirect back to the earliest incomplete step
+    if 'wizard_one_offs' not in session:
+        return redirect(url_for('wizard_bp.wizard_one_offs_step'))
+    if 'wizard_rates' not in session: # Should be caught by one_offs check, but good for robustness
+        return redirect(url_for('wizard_bp.wizard_rates_step'))
+    if 'wizard_expenses' not in session: # Should be caught by rates check, but good for robustness
+        return redirect(url_for('wizard_bp.wizard_expenses_step'))
+
+    # Retrieve all data from session
+    expenses_data = session.get('wizard_expenses', {})
+    rates_data = session.get('wizard_rates', {})
+    one_offs_data = session.get('wizard_one_offs', {})
+
+    # Potentially clear session data after retrieving it if this is the final step
+    # and data is about to be used for calculation, or if there's a "start over" button.
+    # For now, let's keep it in session for easier review and potential "back" navigation.
+    # session.pop('wizard_expenses', None)
+    # session.pop('wizard_rates', None)
+    # session.pop('wizard_one_offs', None)
+
+    return render_template('wizard_summary.html',
+                           title='Wizard Summary',
+                           expenses_data=expenses_data,
+                           rates_data=rates_data,
+                           one_offs_data=one_offs_data)

--- a/templates/_formhelpers.html
+++ b/templates/_formhelpers.html
@@ -1,0 +1,32 @@
+{% macro render_field(field, class="form-control", placeholder="") %}
+  <div class="mb-3">
+    {{ field.label(class="form-label") }}
+    {{ field(class=class ~ (' is-invalid' if field.errors else ''), placeholder=placeholder, **kwargs) }}
+    {% if field.errors %}
+      <div class="invalid-feedback">
+        {% for error in field.errors %}
+          <span>{{ error }}</span><br>
+        {% endfor %}
+      </div>
+    {% endif %}
+    {% if field.description %}
+      <small class="form-text text-muted">{{ field.description }}</small>
+    {% endif %}
+  </div>
+{% endmacro %}
+
+{% macro render_submit_field(field, class="btn btn-primary", formnovalidate=False) %}
+  {{ field(class=class, formnovalidate=formnovalidate if formnovalidate else None) }}
+{% endmacro %}
+
+{% macro render_field_list_item(form_entry, index, list_name, field_names) %}
+<div class="border p-3 mb-3 rounded list-item-entry">
+    <h5>{{ list_name.replace('_', ' ').title() }} #{{ index + 1 }}</h5>
+    <input type="hidden" name="{{ list_name }}-{{ index }}-csrf_token" value="{{ form_entry.csrf_token.current_token }}">
+    {% for field_name in field_names %}
+        {% set field = form_entry[field_name] %}
+        {{ render_field(field, class="form-control form-control-sm", placeholder=field.label.text) }}
+    {% endfor %}
+    {# You could add a remove button here if implementing dynamic removal #}
+</div>
+{% endmacro %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,234 +3,33 @@
 {% block title %}{{ _("FIRE Calculator - Home") }}{% endblock %}
 
 {% block content %}
-  <div class="container index-page"> <!-- .index-page class is already here -->
-    <h2>{{ _("Enter Your Details") }}</h2>
-    {% if error %}
-      <div class="alert alert-danger">{{ error }}</div> {# Error messages from backend are already translated #}
+  <div class="container index-page text-center"> {# Added text-center for centering content #}
+    <h2>{{ _("Plan Your Financial Independence") }}</h2>
+
+    {% if error %} {# Keep error display for any general messages if needed #}
+      <div class="alert alert-danger">{{ error }}</div>
     {% endif %}
-    <form method="post" action="{{ url_for('project.index') }}" class="needs-validation" novalidate id="calculatorForm">
-      <div class="mb-3">
-        <label for="W" class="form-label">{{ _("Annual Expenses (in today's dollars):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Your estimated current annual living expenses.") }}</span></span></label>
-        <input type="number" name="W" id="W" class="form-control" value="{{ request.form.get('W', defaults.W) }}" required min="0">
-      </div>
 
-      <div class="mb-3">
-        <label for="r" class="form-label">{{ _("Overall Annual Return (%%) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected average annual investment return (e.g., 7%% for 7). Used if no specific periods are defined.") }}</span></span></label>
-        <input type="number" name="r" id="r" class="form-control" step="0.1" value="{{ request.form.get('r', defaults.r) }}" min="-50" max="100">
-        <small class="form-text text-muted">{{ _("Used if no periodic rates are specified below.") }}</small>
-      </div>
-      <div class="mb-3">
-        <label for="i" class="form-label">{{ _("Overall Annual Inflation (%%) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected average annual inflation rate (e.g., 3%% for 3). Used if no specific periods are defined.") }}</span></span></label>
-        <input type="number" name="i" id="i" class="form-control" step="0.1" value="{{ request.form.get('i', defaults.i) }}" min="-50" max="100">
-        <small class="form-text text-muted">{{ _("Used if no periodic rates are specified below.") }}</small>
-      </div>
-      <div class="mb-3">
-        <label for="T" class="form-label">{{ _("Total Duration (years) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("How many years your retirement funds need to last. Used if no specific periods are defined.") }}</span></span></label>
-        <input type="number" name="T" id="T" class="form-control" value="{{ request.form.get('T', defaults.T) }}" min="1" step="1">
-        <small class="form-text text-muted">{{ _("Used if no periodic rates are specified below. If using periods, total duration is sum of period durations.") }}</small>
-      </div>
+    <p class="lead mt-4">{{ _("Ready to map out your journey to financial independence? Our new step-by-step wizard will guide you through entering your expenses, expected returns, and any one-off financial events.") }}</p>
 
-      <hr>
-      <h3>{{ _("Periodic Rate Configuration (Optional)") }}</h3>
-      <p><small class="form-text text-muted">{{ _("If any period duration is specified, these periodic rates will override the overall fallback rates above. Unspecified periods will be ignored.") }}</small></p>
-
-      {% for k in range(1, 4) %}
-      <div class="period-group row gx-2 mb-2">
-        <div class="col">
-          <label for="period{{k}}_duration" class="form-label form-label-sm">{{ _("P") }}{{k}} {{ _("Dur.:") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Duration (in years) for this specific period.") }}</span></span></label>
-          <input type="number" name="period{{k}}_duration" id="period{{k}}_duration" class="form-control form-control-sm" value="{{ request.form.get('period{}_duration'.format(k)) or defaults['period{}_duration'.format(k)] }}" min="0" step="1" placeholder="{{ _('Years') }}">
-        </div>
-        <div class="col">
-          <label for="period{{k}}_r" class="form-label form-label-sm">{{ _("P") }}{{k}} {{ _("Ret(%%):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected annual investment return for this period.") }}</span></span></label>
-          <input type="number" name="period{{k}}_r" id="period{{k}}_r" class="form-control form-control-sm" step="0.1" value="{{ request.form.get('period{}_r'.format(k)) or defaults['period{}_r'.format(k)] }}" min="-50" max="100" placeholder="%">
-        </div>
-        <div class="col">
-          <label for="period{{k}}_i" class="form-label form-label-sm">{{ _("P") }}{{k}} {{ _("Inf(%%):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected annual inflation rate for this period.") }}</span></span></label>
-          <input type="number" name="period{{k}}_i" id="period{{k}}_i" class="form-control form-control-sm" step="0.1" value="{{ request.form.get('period{}_i'.format(k)) or defaults['period{}_i'.format(k)] }}" min="-50" max="100" placeholder="%">
-        </div>
-      </div>
-      {% endfor %}
-      <hr>
-
-      {# ONE-OFF EVENTS SECTION START #}
-      <hr>
-      <h3>{{ _("One-off Expenses/Incomes (Optional)") }}</h3>
-      <p><small class="form-text text-muted">{{ _("Add significant one-time expenses (negative values) or incomes (positive values) for specific years. Items with empty year or amount will be ignored by the calculation if not fully specified.") }}</small></p>
-      <div id="one_off_events_container">
-          {# Items rendered by Jinja on page load if form submitted with values #}
-          {% for k in range(1, 6) %} {# Max 5 items for index page (MAX_ONE_OFF_EVENTS_INDEX from Python, hardcoded here) #}
-              {% set year_val = request.form.get('one_off_'~k~'_year') or (defaults and defaults['one_off_'~k~'_year']) %}
-              {% set amount_val = request.form.get('one_off_'~k~'_amount') or (defaults and defaults['one_off_'~k~'_amount']) %}
-              {% if year_val or amount_val %} {# Only render if there's some data from previous submission or defaults #}
-              <div class="one-off-event-item row gx-2 mb-2" data-event-idx="{{ k }}">
-                  <div class="col-md-1 pt-md-4 text-md-end"> {# Adjusted for alignment #}
-                      <label class="form-label-sm">{{ _("Item") }} {{ k }}:</label>
-                  </div>
-                  <div class="col-md-3">
-                      <label for="one_off_{{ k }}_year" class="form-label form-label-sm">{{ _("Year") }}</label>
-                      <input type="number" name="one_off_{{ k }}_year" id="one_off_{{ k }}_year" class="form-control form-control-sm" value="{{ year_val if year_val is not none else '' }}" placeholder="{{ _('Year') }}" min="1" step="1">
-                  </div>
-                  <div class="col-md-4"> <!-- Wider for amount -->
-                      <label for="one_off_{{ k }}_amount" class="form-label form-label-sm">{{ _("Amount") }}</label>
-                      <input type="number" name="one_off_{{ k }}_amount" id="one_off_{{ k }}_amount" class="form-control form-control-sm" value="{{ amount_val if amount_val is not none else '' }}" placeholder="{{ _('Amount (Negative for Expense)') }}" step="any">
-                  </div>
-                  <div class="col-md-2 d-flex align-items-end"> <!-- Remove button column -->
-                      <button type="button" class="btn btn-sm btn-danger remove-one-off-event-item">{{ _("Remove") }}</button>
-                  </div>
-              </div>
-              {% endif %}
-          {% endfor %}
-      </div>
-      <button type="button" id="add_one_off_event_button" class="btn btn-sm btn-outline-secondary mt-2"
-              data-item-label="{{ _('Item') }}"
-              data-year-label="{{ _('Year') }}"
-              data-amount-label="{{ _('Amount') }}"
-              data-amount-placeholder="{{ _('Amount (Negative for Expense)') }}"
-              data-remove-label="{{ _('Remove') }}">
-          {{ _("Add One-off Item") }}
-      </button>
-      <hr class="mt-3">
-      {# ONE-OFF EVENTS SECTION END #}
-
-      <div class="mb-3"> {# Changed from form-group radio-group #}
-        <label class="form-label">{{ _("Withdrawal Timing:") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Choose whether withdrawals occur at the start or end of each year.") }}</span></span></label> {# Main label for the group #}
-        <div class="form-check">
-            <input class="form-check-input" type="radio" name="withdrawal_time" value="start" id="start" {% if request.form.get('withdrawal_time', defaults.withdrawal_time) == 'start' %}checked{% endif %}>
-            <label class="form-check-label" for="start">{{ _("Start of Year") }}</label>
-        </div>
-        <div class="form-check">
-            <input class="form-check-input" type="radio" name="withdrawal_time" value="end" id="end" {% if request.form.get('withdrawal_time', defaults.withdrawal_time) == 'end' or not request.form.get('withdrawal_time', defaults.withdrawal_time) %}checked{% endif %}>
-            <label class="form-check-label" for="end">{{ _("End of Year") }}</label>
-        </div>
-      </div>
-      <div class="mb-3">
-        <label for="D" class="form-label">{{ _("Desired Final Portfolio Value") }} ({{ DEFAULT_CURRENCY }}):<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("The amount you wish to have remaining at the end of the retirement duration. Default is $0.") }}</span></span></label>
-        <input type="number" name="D" id="D" class="form-control" value="{{ request.form.get('D', defaults.D) }}" step="any" min="0">
-        <small class="form-text text-muted">{{ _("Optional. The portfolio value you want remaining at the end of the term.") }}</small>
-      </div>
-      <button type="submit" class="btn btn-primary">{{ _("Calculate") }}</button>
-    </form>
-    <div class="mt-4 text-center"> {# Added margin and text centering for the link/button #}
-      <a href="{{ url_for('project.compare') }}" class="btn btn-secondary">{{ _("Compare Scenarios") }}</a>
+    <div class="mt-4 mb-4"> {# Added margin for spacing #}
+      <a href="{{ url_for('wizard_bp.wizard_expenses_step') }}" class="btn btn-primary btn-lg">
+        {{ _("Start the FIRE Wizard") }}
+      </a>
     </div>
+
+    <p>{{ _("The wizard makes it easier to enter your details and ensures everything is validated along the way.") }}</p>
+
+    <hr class="my-4"> {# A thematic break #}
+
+    <h4>{{ _("Other Tools") }}</h4>
+    <div class="mt-3">
+      <a href="{{ url_for('project.compare') }}" class="btn btn-secondary">{{ _("Compare Scenarios") }}</a>
+      {# Add other links here if necessary, e.g., to a direct calculation if some simplified default data model were to be kept, but current plan replaces it. #}
+    </div>
+
   </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    const container = document.getElementById('one_off_events_container');
-    const addButton = document.getElementById('add_one_off_event_button');
-    const maxEvents = 5; // Corresponds to MAX_ONE_OFF_EVENTS_INDEX
-
-    // Helper to get translations from button data attributes
-    const itemLabel = addButton.dataset.itemLabel;
-    const yearLabelText = addButton.dataset.yearLabel; // Renamed to avoid conflict with label element
-    const amountLabelText = addButton.dataset.amountLabel; // Renamed to avoid conflict
-    const amountPlaceholder = addButton.dataset.amountPlaceholder;
-    const removeButtonText = addButton.dataset.removeLabel;
-
-    function getVisibleEventCount() {
-        return container.querySelectorAll('.one-off-event-item:not(.d-none)').length;
-    }
-
-    function updateAddButtonVisibility() {
-        if (getVisibleEventCount() >= maxEvents) {
-            addButton.style.display = 'none';
-        } else {
-            addButton.style.display = '';
-        }
-    }
-
-    function getNextAvailableIndex() {
-        for (let i = 1; i <= maxEvents; i++) {
-            // Check if an item with this index exists AND is visible (not .d-none)
-            const existingItem = container.querySelector(`.one-off-event-item[data-event-idx="${i}"]`);
-            if (!existingItem || existingItem.classList.contains('d-none')) {
-                 // If it doesn't exist, or exists but is hidden, this index is available.
-                return i;
-            }
-        }
-        // This case should ideally not be reached if updateAddButtonVisibility works correctly,
-        // but as a fallback if all maxEvents slots are technically filled (even if some are hidden by direct manipulation not through remove button).
-        // However, the primary logic is to find the first slot that is either not there or is hidden.
-        // Let's refine: find first slot not present OR present and hidden.
-        // The logic in the loop already does this: if !existingItem (not present), return i.
-        // If existingItem.classList.contains('d-none') (present but hidden), return i.
-        // So, if the loop finishes, it means all slots 1 to maxEvents are present AND visible.
-        return null; // No available index if all are visible
-    }
-
-    function wireRemoveButton(eventItem) {
-        const removeButton = eventItem.querySelector('.remove-one-off-event-item');
-        removeButton.addEventListener('click', function () {
-            // Hide the item and clear its values. Backend will ignore items with no year/amount.
-            eventItem.classList.add('d-none');
-            const inputs = eventItem.querySelectorAll('input[type="number"]');
-            inputs.forEach(input => {
-                input.value = '';
-                // input.dispatchEvent(new Event('input')); // Optional: if other JS relies on it
-            });
-            updateAddButtonVisibility();
-        });
-    }
-
-    addButton.addEventListener('click', function () {
-        const currentVisibleCount = getVisibleEventCount();
-        if (currentVisibleCount >= maxEvents) { // This check is belts and suspenders, updateAddButtonVisibility should handle it
-            return;
-        }
-
-        const nextIdx = getNextAvailableIndex();
-        if (nextIdx === null) { // All slots are filled and visible
-            updateAddButtonVisibility(); // Ensure button is hidden
-            return;
-        }
-
-        let eventItemDiv = container.querySelector(`.one-off-event-item[data-event-idx="${nextIdx}"]`);
-
-        if (eventItemDiv && eventItemDiv.classList.contains('d-none')) { // Item exists but was hidden
-            eventItemDiv.classList.remove('d-none');
-            // Ensure values are cleared (should be by remove logic, but good practice)
-            eventItemDiv.querySelectorAll('input[type="number"]').forEach(input => input.value = '');
-        } else if (!eventItemDiv) { // Item does not exist, create it
-            eventItemDiv = document.createElement('div');
-            eventItemDiv.classList.add('one-off-event-item', 'row', 'gx-2', 'mb-2');
-            eventItemDiv.setAttribute('data-event-idx', nextIdx);
-
-            eventItemDiv.innerHTML = `
-                <div class="col-md-1 pt-md-4 text-md-end">
-                    <label class="form-label-sm">${itemLabel} ${nextIdx}:</label>
-                </div>
-                <div class="col-md-3">
-                    <label for="one_off_${nextIdx}_year" class="form-label form-label-sm">${yearLabelText}</label>
-                    <input type="number" name="one_off_${nextIdx}_year" id="one_off_${nextIdx}_year" class="form-control form-control-sm" placeholder="${yearLabelText}" min="1" step="1">
-                </div>
-                <div class="col-md-4">
-                    <label for="one_off_${nextIdx}_amount" class="form-label form-label-sm">${amountLabelText}</label>
-                    <input type="number" name="one_off_${nextIdx}_amount" id="one_off_${nextIdx}_amount" class="form-control form-control-sm" placeholder="${amountPlaceholder}" step="any">
-                </div>
-                <div class="col-md-2 d-flex align-items-end">
-                    <button type="button" class="btn btn-sm btn-danger remove-one-off-event-item">${removeButtonText}</button>
-                </div>
-            `;
-            container.appendChild(eventItemDiv);
-            wireRemoveButton(eventItemDiv);
-        }
-
-        updateAddButtonVisibility();
-    });
-
-    // Wire remove buttons for items rendered by Jinja and not hidden by default
-    container.querySelectorAll('.one-off-event-item').forEach(item => {
-        // If an item is rendered by Jinja, it means it had data.
-        // We assume it should be visible unless specifically made d-none by some other logic (not the case here).
-        // The Jinja loop only renders items if year_val or amount_val is present.
-        // These rendered items should have their remove buttons wired.
-        if (!item.classList.contains('d-none')) { // Only wire for visible items
-             wireRemoveButton(item);
-        }
-    });
-
-    updateAddButtonVisibility(); // Initial check on page load
-});
-</script>
+  {# Remove the old JavaScript for one-off events; it's no longer needed here. #}
+  {# The <script> block related to 'one_off_events_container' should be deleted. #}
 {% endblock %}

--- a/templates/wizard_expenses.html
+++ b/templates/wizard_expenses.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% from "_formhelpers.html" import render_field, render_submit_field %}
+
+{% block title %}{{ title }} - {{ super() }}{% endblock %}
+
+{% block content %}
+  <h2>{{ title }}</h2>
+  <p>{{ _("Please enter your current annual expenses. This will help us understand your baseline financial needs.") }}</p>
+  <form method="POST" action="{{ url_for('wizard_bp.wizard_expenses_step') }}" novalidate>
+    {{ form.csrf_token }}
+    <fieldset>
+      <legend class="visually-hidden">{{ _("Expenses Form") }}</legend>
+      {{ render_field(form.annual_expenses, class="form-control", placeholder=_("e.g., 50000")) }}
+      {{ render_field(form.housing, class="form-control", placeholder=_("e.g., 15000")) }}
+      {{ render_field(form.food, class="form-control", placeholder=_("e.g., 6000")) }}
+      {{ render_field(form.transportation, class="form-control", placeholder=_("e.g., 5000")) }}
+      {{ render_field(form.utilities, class="form-control", placeholder=_("e.g., 3000")) }}
+      {{ render_field(form.personal_care, class="form-control", placeholder=_("e.g., 2000")) }}
+      {{ render_field(form.entertainment, class="form-control", placeholder=_("e.g., 4000")) }}
+      {{ render_field(form.healthcare, class="form-control", placeholder=_("e.g., 3000")) }}
+      {{ render_field(form.other_expenses, class="form-control", placeholder=_("e.g., 1000")) }}
+    </fieldset>
+    {{ render_submit_field(form.submit, class="btn btn-primary mt-3") }}
+  </form>
+{% endblock %}

--- a/templates/wizard_one_offs.html
+++ b/templates/wizard_one_offs.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% from "_formhelpers.html" import render_field, render_submit_field, render_field_list_item %}
+
+{% block title %}{{ title }} - {{ super() }}{% endblock %}
+
+{% block content %}
+  <h2>{{ title }}</h2>
+  <p>{{ _("List any significant one-time expenses (e.g., buying a car, wedding) or incomes (e.g., inheritance, sale of asset) you anticipate.") }}</p>
+  <form method="POST" action="{{ url_for('wizard_bp.wizard_one_offs_step') }}" novalidate>
+    {{ form.csrf_token }}
+
+    <fieldset class="mb-3">
+      <legend>{{ _("Large One-Off Expenses") }}</legend>
+      <div id="large-expenses-list">
+        {% for expense_form in form.large_expenses %}
+         {{ render_field_list_item(expense_form, loop.index0, 'large_expenses', ['year', 'amount', 'description']) }}
+        {% endfor %}
+      </div>
+      {{ render_submit_field(form.submit_add_expense, class="btn btn-secondary btn-sm mt-2", formnovalidate=True) }}
+    </fieldset>
+
+    <fieldset>
+      <legend>{{ _("Large One-Off Incomes") }}</legend>
+      <div id="large-incomes-list">
+        {% for income_form in form.large_incomes %}
+          {{ render_field_list_item(income_form, loop.index0, 'large_incomes', ['year', 'amount', 'description']) }}
+        {% endfor %}
+      </div>
+      {{ render_submit_field(form.submit_add_income, class="btn btn-secondary btn-sm mt-2", formnovalidate=True) }}
+    </fieldset>
+
+    {{ render_submit_field(form.submit, class="btn btn-primary mt-4") }}
+  </form>
+{% endblock %}

--- a/templates/wizard_rates.html
+++ b/templates/wizard_rates.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% from "_formhelpers.html" import render_field, render_submit_field, render_field_list_item %}
+
+{% block title %}{{ title }} - {{ super() }}{% endblock %}
+
+{% block content %}
+  <h2>{{ title }}</h2>
+  <p>{{ _("Define your expected investment returns and inflation. You can also specify different return rates for distinct periods if needed.") }}</p>
+  <form method="POST" action="{{ url_for('wizard_bp.wizard_rates_step') }}" novalidate>
+    {{ form.csrf_token }}
+    <fieldset>
+      <legend class="visually-hidden">{{ _("Rates Form") }}</legend>
+      {{ render_field(form.return_rate, class="form-control", placeholder=_("e.g., 7")) }}
+      {{ render_field(form.inflation_rate, class="form-control", placeholder=_("e.g., 2.5")) }}
+
+      <h4 class="mt-4">{{ _("Period-Specific Return Rates (Optional)") }}</h4>
+      <p><small>{{_("If you expect your investment return rate to change over time (e.g., lower returns in retirement), define those periods here. Otherwise, leave blank.")}}</small></p>
+      <div id="period-rates-list">
+        {% for period_form in form.period_rates %}
+          {{ render_field_list_item(period_form, loop.index0, 'period_rates', ['years', 'rate']) }}
+        {% endfor %}
+      </div>
+      {{ render_submit_field(form.submit_add_period, class="btn btn-secondary btn-sm mt-2", formnovalidate=True) }}
+    </fieldset>
+    {{ render_submit_field(form.submit, class="btn btn-primary mt-3") }}
+  </form>
+{% endblock %}

--- a/templates/wizard_summary.html
+++ b/templates/wizard_summary.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }} - {{ super() }}{% endblock %}
+
+{% block content %}
+  <h2>{{ title }}</h2>
+  <p>{{ _("Please review the information you've provided. If everything is correct, you can proceed to calculate your FIRE projection.") }}</p>
+
+  <div class="card mb-3">
+    <div class="card-header">
+      <h4>{{ _("Expenses Summary") }}</h4>
+    </div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item"><strong>{{ _("Total Annual Expenses:") }}</strong> {{ expenses_data.annual_expenses | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Housing:") }}</strong> {{ expenses_data.housing | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Food:") }}</strong> {{ expenses_data.food | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Transportation:") }}</strong> {{ expenses_data.transportation | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Utilities:") }}</strong> {{ expenses_data.utilities | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Personal Care:") }}</strong> {{ expenses_data.personal_care | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Entertainment:") }}</strong> {{ expenses_data.entertainment | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Healthcare:") }}</strong> {{ expenses_data.healthcare | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Other Expenses:") }}</strong> {{ expenses_data.other_expenses | default(_('N/A')) }}</li>
+    </ul>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-header">
+      <h4>{{ _("Rates Summary") }}</h4>
+    </div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item"><strong>{{ _("Overall Portfolio Return Rate (%):") }}</strong> {{ rates_data.return_rate | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Assumed Annual Inflation Rate (%):") }}</strong> {{ rates_data.inflation_rate | default(_('N/A')) }}</li>
+      {% if rates_data.period_rates %}
+        <li class="list-group-item"><strong>{{ _("Period-Specific Return Rates:") }}</strong></li>
+        {% for period in rates_data.period_rates %}
+          {% if period.years and period.rate is not none %} {# Check if period has data #}
+            <li class="list-group-item ms-3">&bull; {{ _("Years:") }} {{ period.years }}, {{ _("Rate:") }} {{ period.rate }}%</li>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+    </ul>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-header">
+      <h4>{{ _("One-Off Events Summary") }}</h4>
+    </div>
+    {% if one_offs_data.large_expenses %}
+      <div class="card-body">
+        <h5>{{ _("Large One-Off Expenses:") }}</h5>
+        <ul class="list-group">
+          {% for expense in one_offs_data.large_expenses %}
+            {% if expense.year is not none and expense.amount is not none %} {# Check if expense has data #}
+              <li class="list-group-item">{{ _("Year:") }} {{ expense.year }}, {{ _("Amount:") }} {{ expense.amount }}{% if expense.description %}, {{ _("Desc:") }} {{ expense.description }}{% endif %}</li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+    {% if one_offs_data.large_incomes %}
+      <div class="card-body">
+        <h5>{{ _("Large One-Off Incomes:") }}</h5>
+        <ul class="list-group">
+          {% for income in one_offs_data.large_incomes %}
+            {% if income.year is not none and income.amount is not none %} {# Check if income has data #}
+              <li class="list-group-item">{{ _("Year:") }} {{ income.year }}, {{ _("Amount:") }} {{ income.amount }}{% if income.description %}, {{ _("Desc:") }} {{ income.description }}{% endif %}</li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+    {% if not one_offs_data.large_expenses and not one_offs_data.large_incomes %}
+        <div class="card-body">
+            <p>{{_("No one-off events were specified.")}}</p>
+        </div>
+    {% endif %}
+  </div>
+
+  <div class="mt-4">
+    {# TODO: Add a button/link to "Edit" previous steps, possibly by linking to wizard_bp.wizard_expenses_step etc. #}
+    {# TODO: Add a button/form to "Calculate" or "Finalize" which would POST this data (or trigger calculation) #}
+    <a href="{{ url_for('wizard_bp.wizard_one_offs_step') }}" class="btn btn-secondary">{{ _("Back to One-Offs") }}</a>
+    <a href="{{ url_for('project.index') }}" class="btn btn-primary">{{ _("Calculate with this Data (Placeholder)") }}</a>
+     <p class="mt-2"><small>{{_("Note: The 'Calculate' button is a placeholder. Functionality to use this data for calculation will be added later.")}}</small></p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new multi-step wizard for data input, replacing the previous single-page form on the homepage.

Key changes include:

1.  **WTForms Defined:** Created `ExpensesForm`, `RatesForm`, `OneOffsForm`, and helper sub-forms (`PeriodRateForm`, `OneOffEntryForm`) in `project/forms.py`. These forms include validators for robust data entry.
2.  **Flask Blueprint:** Established `wizard_bp` in `project/wizard_routes.py` to encapsulate all wizard-related routes.
3.  **Wizard Routes:** Implemented routes for each step (`/wizard/expenses`, `/wizard/rates`, `/wizard/one_offs`) handling GET/POST requests, data validation, session storage, and sequential navigation. A `/wizard/summary` route displays collected data.
4.  **CSRF Protection:** Integrated `CSRFProtect` in `app.py` for enhanced security.
5.  **HTML Templates:** Developed new templates for each wizard step and a summary page (`wizard_expenses.html`, `wizard_rates.html`, `wizard_one_offs.html`, `wizard_summary.html`) and a `_formhelpers.html` for consistent rendering. Templates include CSRF tokens and use Bootstrap styling.
6.  **Blueprint Registration:** Registered `wizard_bp` in `app.py`.
7.  **Homepage Update:** Modified `templates/index.html` to remove the old form and direct users to the new wizard.

Next, I planned to implement comprehensive unit tests for the new forms and wizard routes to ensure functionality and prevent regressions, as per your feedback. This includes the completed implementation work up to the point of test creation.