### PR TITLE
fix: Escape percentage signs in wizard_summary.html translations

### DIFF
--- a/templates/wizard_summary.html
+++ b/templates/wizard_summary.html
@@ -28,8 +28,8 @@
       <h4>{{ _("Rates Summary") }}</h4>
     </div>
     <ul class="list-group list-group-flush">
-      <li class="list-group-item"><strong>{{ _("Overall Portfolio Return Rate (%):") }}</strong> {{ rates_data.return_rate | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Assumed Annual Inflation Rate (%):") }}</strong> {{ rates_data.inflation_rate | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Overall Portfolio Return Rate (%%):") }}</strong> {{ rates_data.return_rate | default(_('N/A')) }}</li>
+      <li class="list-group-item"><strong>{{ _("Assumed Annual Inflation Rate (%%):") }}</strong> {{ rates_data.inflation_rate | default(_('N/A')) }}</li>
       {% if rates_data.period_rates %}
         <li class="list-group-item"><strong>{{ _("Period-Specific Return Rates:") }}</strong></li>
         {% for period in rates_data.period_rates %}


### PR DESCRIPTION
This commit resolves a ValueError (`unsupported format character ')' (0x29)`) that occurred during template rendering in `templates/wizard_summary.html`.

The error was caused by unescaped literal '%' characters within strings passed to the `_()` (gettext) translation function. These have been corrected by changing '%' to '%%'.

Specifically:
- Changed `_("Overall Portfolio Return Rate (%):")` to `_("Overall Portfolio Return Rate (%%):")`
- Changed `_("Assumed Annual Inflation Rate (%):")` to `_("Assumed Annual Inflation Rate (%%):")`

Reviewed `templates/wizard_rates.html` and confirmed it does not contain similar problematic `_()` calls.