### PR TITLE
fix: Resolve SyntaxError from repeated keyword argument in wizard_cal…

### DIFF
--- a/project/wizard_routes.py
+++ b/project/wizard_routes.py
@@ -329,7 +329,6 @@ def wizard_calculate_step():
                                table_rows=table_rows,
                                plot1_div=plot1_div,
                                plot2_div=plot2_div,
-                               W=W, # Raw W is already passed
                                r_overall_nominal=r_overall_nominal,
                                i_overall=i_overall,
                                rates_periods_summary=rates_periods,


### PR DESCRIPTION
…culate_step

This commit fixes a SyntaxError (`keyword argument repeated: W`) that occurred in the `wizard_calculate_step` function in `project/wizard_routes.py`.

The error was caused by the `W` variable being passed twice as a keyword argument to the `render_template` call for `wizard_results.html` in the success path. The redundant instance has been removed.