### PR TITLE
feat: Dual plots, sliders for what-if, and optional itemized expenses

### DIFF
--- a/project/forms.py
+++ b/project/forms.py
@@ -16,14 +16,14 @@ class OneOffEntryForm(FlaskForm):
 class ExpensesForm(FlaskForm):
     '''Form for capturing all annual expenses.'''
     annual_expenses = FloatField('Total Current Annual Expenses', validators=[DataRequired(), NumberRange(min=0)])
-    housing = FloatField('Housing (e.g., rent/mortgage, property tax, insurance)', validators=[DataRequired(), NumberRange(min=0)])
-    food = FloatField('Food (groceries, dining out)', validators=[DataRequired(), NumberRange(min=0)])
-    transportation = FloatField('Transportation (car payments, fuel, public transport, maintenance)', validators=[DataRequired(), NumberRange(min=0)])
-    utilities = FloatField('Utilities (electricity, water, gas, internet, phone)', validators=[DataRequired(), NumberRange(min=0)])
-    personal_care = FloatField('Personal Care (haircuts, toiletries, gym)', validators=[DataRequired(), NumberRange(min=0)])
-    entertainment = FloatField('Entertainment (hobbies, subscriptions, travel)', validators=[DataRequired(), NumberRange(min=0)])
-    healthcare = FloatField('Healthcare (insurance premiums, medical expenses)', validators=[DataRequired(), NumberRange(min=0)])
-    other_expenses = FloatField('Other Miscellaneous Expenses', validators=[DataRequired(), NumberRange(min=0)])
+    housing = FloatField('Housing (e.g., rent/mortgage, property tax, insurance)', validators=[Optional(), NumberRange(min=0)])
+    food = FloatField('Food (groceries, dining out)', validators=[Optional(), NumberRange(min=0)])
+    transportation = FloatField('Transportation (car payments, fuel, public transport, maintenance)', validators=[Optional(), NumberRange(min=0)])
+    utilities = FloatField('Utilities (electricity, water, gas, internet, phone)', validators=[Optional(), NumberRange(min=0)])
+    personal_care = FloatField('Personal Care (haircuts, toiletries, gym)', validators=[Optional(), NumberRange(min=0)])
+    entertainment = FloatField('Entertainment (hobbies, subscriptions, travel)', validators=[Optional(), NumberRange(min=0)])
+    healthcare = FloatField('Healthcare (insurance premiums, medical expenses)', validators=[Optional(), NumberRange(min=0)])
+    other_expenses = FloatField('Other Miscellaneous Expenses', validators=[Optional(), NumberRange(min=0)])
     submit = SubmitField('Next: Rates')
 
 class RatesForm(FlaskForm):

--- a/project/wizard_routes.py
+++ b/project/wizard_routes.py
@@ -249,7 +249,7 @@ def wizard_calculate_step():
         if sim_years is not None and sim_balances is not None and len(sim_years) > 0:
             try:
                 fig_balance = go.Figure()
-                fig_balance.add_trace(go.Scatter(x=sim_years, y=sim_balances[1:], mode='lines+markers', name="Portfolio Balance"))
+                fig_balance.add_trace(go.Scatter(x=sim_years, y=sim_balances[1:], mode='lines+markers', name="Portfolio Balance", line=dict(color='blue')))
                 for event in one_off_events: # one_off_events is already available from transformation
                     if event['year'] <= sim_years[-1]:
                         event_y_approx = sim_balances[min(event['year'], len(sim_balances)-1)] # Approximate y for marker
@@ -258,7 +258,7 @@ def wizard_calculate_step():
                             marker=dict(size=10, color='red' if event['amount'] < 0 else 'green', symbol='triangle-down' if event['amount'] < 0 else 'triangle-up'),
                             name=f"One-off: {event['amount']:.0f}"
                         ))
-                fig_balance.update_layout(title="Portfolio Balance Over Time", xaxis_title="Year", yaxis_title="Portfolio Balance", legend_title_text="Legend")
+                fig_balance.update_layout(title="Portfolio Balance Over Time", xaxis_title="Year", yaxis_title="Portfolio Balance", legend_title_text="Legend") # Original titles are fine
                 plot1_div = to_html(fig_balance, full_html=False, include_plotlyjs='cdn')
             except Exception as e_plot1:
                 current_app.logger.error(f"Error generating balance plot: {e_plot1}", exc_info=True)
@@ -267,8 +267,8 @@ def wizard_calculate_step():
         if sim_years is not None and sim_withdrawals is not None and len(sim_years) > 0:
             try:
                 fig_withdrawals = go.Figure()
-                fig_withdrawals.add_trace(go.Scatter(x=sim_years, y=sim_withdrawals, mode='lines+markers', name="Annual Withdrawal"))
-                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount", legend_title_text="Legend")
+                fig_withdrawals.add_trace(go.Scatter(x=sim_years, y=sim_withdrawals, mode='lines+markers', name="Annual Withdrawal", line=dict(color='blue')))
+                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount", legend_title_text="Legend") # Original titles are fine
                 plot2_div = to_html(fig_withdrawals, full_html=False, include_plotlyjs='cdn')
             except Exception as e_plot2:
                 current_app.logger.error(f"Error generating withdrawal plot: {e_plot2}", exc_info=True)
@@ -437,16 +437,16 @@ def wizard_recalculate_interactive():
         if sim_years is not None and sim_balances is not None and len(sim_years) > 0 :
             try:
                 fig_balance = go.Figure()
-                fig_balance.add_trace(go.Scatter(x=sim_years, y=sim_balances[1:], mode='lines+markers', name="Portfolio Balance"))
+                fig_balance.add_trace(go.Scatter(x=sim_years, y=sim_balances[1:], mode='lines+markers', name="Portfolio Balance (What-If)", line=dict(color='green')))
                 for event in one_off_events_for_calc:
                     if event['year'] <= sim_years[-1]:
                         event_y_approx = sim_balances[min(event['year'], len(sim_balances)-1)]
                         fig_balance.add_trace(go.Scatter(
                             x=[event['year']], y=[event_y_approx], mode='markers',
                             marker=dict(size=10, color='red' if event['amount'] < 0 else 'green', symbol='triangle-down' if event['amount'] < 0 else 'triangle-up'),
-                            name=f"One-off: {event['amount']:.0f}"
+                            name=f"One-off: {event['amount']:.0f}" # One-off event names can remain same
                         ))
-                fig_balance.update_layout(title="Portfolio Balance Over Time", xaxis_title="Year", yaxis_title="Portfolio Balance")
+                fig_balance.update_layout(title="Portfolio Balance Over Time (What-If)", xaxis_title="Year", yaxis_title="Portfolio Balance")
                 plot1_div_html = to_html(fig_balance, full_html=False, include_plotlyjs='cdn')
             except Exception as e_plot1:
                 current_app.logger.error(f"Error generating balance plot for AJAX: {e_plot1}", exc_info=True)
@@ -454,8 +454,8 @@ def wizard_recalculate_interactive():
         if sim_years is not None and sim_withdrawals is not None and len(sim_years) > 0:
             try:
                 fig_withdrawals = go.Figure()
-                fig_withdrawals.add_trace(go.Scatter(x=sim_years, y=sim_withdrawals, mode='lines+markers', name="Annual Withdrawal"))
-                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount")
+                fig_withdrawals.add_trace(go.Scatter(x=sim_years, y=sim_withdrawals, mode='lines+markers', name="Annual Withdrawal (What-If)", line=dict(color='green')))
+                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time (What-If)", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount")
                 plot2_div_html = to_html(fig_withdrawals, full_html=False, include_plotlyjs='cdn')
             except Exception as e_plot2:
                 current_app.logger.error(f"Error generating withdrawal plot for AJAX: {e_plot2}", exc_info=True)

--- a/templates/wizard_results.html
+++ b/templates/wizard_results.html
@@ -23,25 +23,22 @@
       {{_("Calculation Summary")}}
     </div>
     <div class="card-body">
-      {# Prominent Main Result #}
       {% if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" %}
         <h3 class="card-title">{{_("Your Calculated FIRE Number:")}}</h3>
-        <p class="display-4 fw-bold text-success">{{ P_calculated_display }}</p>
+        <p id="display_p" class="display-4 fw-bold text-success">{{ P_calculated_display }}</p> {# Static Original P #}
         <hr>
         <h5 class="card-title mt-3">{{_("Based on:")}}</h5>
-        <p class="card-text fs-5 mb-1">
+        <p id="display_w" class="card-text fs-5 mb-1"> {# Static Original W #}
           {{_("Input Annual Expenses (W):")}} <strong>{{ W_display }}</strong>
         </p>
       {% elif P_calculated_display %}
-        <div class="alert alert-warning" role="alert"> {# Changed to alert instead of separate card for error case display #}
+        <div class="alert alert-warning" role="alert">
             <h4 class="alert-heading">{{_("Calculation Outcome")}}</h4>
-            <p class="fs-5">{{_("Calculated Required Initial Portfolio (FIRE Number):")}} <strong>{{ P_calculated_display }}</strong></p>
+            <p class="fs-5">{{_("Calculated Required Initial Portfolio (FIRE Number):")}} <strong id="display_p">{{ P_calculated_display }}</strong></p>
             <hr>
-            <p class="mb-0">{{_("Based on Input Annual Expenses (W):")}} <strong>{{ W_display | default(W) }}</strong></p>
+            <p class="mb-0">{{_("Based on Input Annual Expenses (W):")}} <strong id="display_w">{{ W_display | default(W) }}</strong></p>
         </div>
       {% endif %}
-
-      {# Consolidated Fixed Inputs - made more concise #}
       <div class="mt-3 text-muted small">
         <p class="mb-1">
           {{_("Overall Nominal Return:")}} {{ (r_overall_nominal * 100) | round(2) }}% |
@@ -62,72 +59,69 @@
         {% endif %}
       </div>
     </div>
-  </div>{# End of Main Key Results & Consolidated Fixed Inputs Card #}
+  </div>
 
-  {# --- Interactive What-If Analysis (Moved Here) --- #}
-  <div class="card text-center mb-4">
+  {# --- Static Original Calculation Plots (Side-by-Side) --- #}
+  <h3 class="mt-4 mb-3 text-center">{{_("Original Calculation Plots")}}</h3>
+  {% if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" %}
+    <div class="row">
+      <div id="original_plot1_container" class="col-md-6 mb-3">
+        {{ plot1_div | safe }} {# This is the original plot1_div from wizard_calculate_step #}
+      </div>
+      <div id="original_plot2_container" class="col-md-6 mb-3">
+        {{ plot2_div | safe }} {# This is the original plot2_div from wizard_calculate_step #}
+      </div>
+    </div>
+  {% else %}
+    <p class="text-center">{{_("Original plots not available due to calculation error or infeasible scenario.")}}</p>
+  {% endif %}
+
+  {# --- Interactive What-If Analysis (Card with Sliders and its own Plots) --- #}
+  <div class="card text-center mb-4 mt-5">
     <div class="card-header">
       {{_("Interactive What-If Analysis")}}
     </div>
     <div class="card-body">
-      <div class="row g-3 align-items-center justify-content-center">
-        <div class="col-auto">
+      {# Row for W input and slider #}
+      <div class="row g-3 align-items-center justify-content-center mb-3">
+        <div class="col-md-3 text-md-end">
           <label for="interactive_w" class="col-form-label">{{_("Adjust Annual Expenses (W):")}}</label>
         </div>
-        <div class="col-auto">
-          <input type="number" id="interactive_w" class="form-control" value="{{ W | default(0.0) }}" step="1000">
+        <div class="col-md-3">
+          <input type="number" id="interactive_w" class="form-control interactive-input" data-changed="W" value="{{ W | default(0.0) }}" step="1000" min="0">
         </div>
-        <div class="col-auto p-3">
-            <i class="fas fa-exchange-alt fa-2x"></i> {# Placeholder for arrows or visual cue - FontAwesome needed #}
+        <div class="col-md-6">
+          <input type="range" id="slider_w" class="form-range interactive-slider" data-target="interactive_w" value="{{ W | default(0.0) }}" min="0" max="{{ (W * 2) | default(100000) | int }}" step="1000">
         </div>
-        <div class="col-auto">
+      </div>
+
+      {# Row for P input and slider #}
+      <div class="row g-3 align-items-center justify-content-center mb-3">
+        <div class="col-md-3 text-md-end">
           <label for="interactive_p" class="col-form-label">{{_("Adjust Target Portfolio (P):")}}</label>
         </div>
-        <div class="col-auto">
-          <input type="number" id="interactive_p" class="form-control" value="{{ P_raw | default(0.0) }}" step="10000">
+        <div class="col-md-3">
+          <input type="number" id="interactive_p" class="form-control interactive-input" data-changed="P" value="{{ P_raw | default(0.0) }}" step="10000" min="0">
+        </div>
+        <div class="col-md-6">
+          <input type="range" id="slider_p" class="form-range interactive-slider" data-target="interactive_p" value="{{ P_raw | default(0.0) }}" min="0" max="{{ (P_raw * 2) | default(2000000) | int }}" step="10000">
         </div>
       </div>
-       <small class="form-text text-muted mt-2">{{_("Change one value to see how it impacts the other. Other parameters (rates, duration) remain fixed as per your wizard inputs.")}}</small>
-    </div>
-  </div> {# End of Interactive Analysis Card #}
+      <small class="form-text text-muted mt-2">{{_("Change one value or use slider to see how it impacts the other. Plots below will update.")}}</small>
 
-  {# Prominent Results Display for Interactive changes (dynamic) - This div is distinct from the initial result display #}
-  {# The initial display is now part of the "Calculation Summary" card when P_calculated_display is valid #}
-  {# This #dynamic-results-display div is for JS to update the main P and W numbers if needed, or can be removed if inputs directly reflect the state #}
-  {# Based on current JS, only input fields and plots are updated. So, the static display in "Calculation Summary" remains the reference from initial calculation. #}
-  {# The prompt asked for a section with id="dynamic-results-display" to be populated by JS. #}
-  {# Let's make it clearer: the initial display is in the summary card. JS updates interactive inputs and plots. #}
-  {# The div below can be a target for JS to write *newly calculated* P and W if we want them displayed outside inputs. #}
-  {# For now, current JS updates input fields and plots, not separate static text. #}
-  {# The original plan had a display section: #}
-  <!--
-  <div id="dynamic-results-display" class="text-center mb-4">
-    <h3 class="card-title">{{_("Calculated FIRE Number:")}}</h3>
-    <p id="display_p" class="display-4 fw-bold text-success">{{ P_calculated_display }}</p>
-    <hr>
-    <h5 class="card-title mt-3">{{_("Sustainable Annual Expenses:")}}</h5>
-    <p id="display_w" class="fs-5 card-text"><strong>{{ W_display }}</strong></p>
+      {# New Plot Containers for Interactive Analysis (Side-by-Side) #}
+      <div class="row mt-4">
+        <div id="interactive_plot1_container" class="col-md-6 mb-3">
+          <p>{{_("Interactive plots will appear here after adjustment.")}}</p>
+        </div>
+        <div id="interactive_plot2_container" class="col-md-6 mb-3">
+          {# This will be populated by JS. #}
+        </div>
+      </div>
+    </div>
   </div>
-  -->
-  {# This section was part of the previous HTML structure. The current JS updates interactive_w/p fields and plots. #}
-  {# If a separate static display is still desired for interactive updates, JS needs to target it. #}
-  {# For now, I'm removing this duplicate static display as the interactive fields themselves show the current values. #}
-  {# The "Key Results" section already displays the initial calculation. #}
 
-
-  {# --- Plots (Now After Interactive Card) --- #}
-  {% if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" %}
-    <div class="row">
-      <div id="plot1_container" class="col-md-12 mb-3">
-        {{ plot1_div | safe }}
-      </div>
-      <div id="plot2_container" class="col-md-12">
-        {{ plot2_div | safe }}
-      </div>
-    </div>
-  {% endif %}
-
-  {# Hidden fields/script tags for fixed parameters (can remain at top or bottom of content block) #}
+  {# Hidden fields/script tags for fixed parameters #}
   <input type="hidden" id="initial_r_overall_nominal" value="{{ r_overall_nominal | default(0.0) }}">
   <input type="hidden" id="initial_i_overall" value="{{ i_overall | default(0.0) }}">
   <input type="hidden" id="initial_total_duration_from_periods" value="{{ total_duration_from_periods | default(30) }}">
@@ -148,11 +142,9 @@
 document.addEventListener('DOMContentLoaded', function() {
     const interactiveWField = document.getElementById('interactive_w');
     const interactivePField = document.getElementById('interactive_p');
-    // const displayPElement = document.getElementById('display_p'); // Not updated by this JS
-    // const displayWElement = document.getElementById('display_w'); // Not updated by this JS
 
-    const plot1Container = document.getElementById('plot1_container');
-    const plot2Container = document.getElementById('plot2_container');
+    const plot1Container = document.getElementById('interactive_plot1_container'); // Target new interactive plot container
+    const plot2Container = document.getElementById('interactive_plot2_container'); // Target new interactive plot container
 
     const initialROverallNominal = parseFloat(document.getElementById('initial_r_overall_nominal').value);
     const initialIOverall = parseFloat(document.getElementById('initial_i_overall').value);
@@ -186,27 +178,48 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('CSRF token not found!');
     }
 
-
     let debounceTimer;
 
     function handleInputChange(event) {
         clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
-            const changedInputId = event.target.id;
-            let changed_input_type = '';
-            if (changedInputId === 'interactive_w') {
-                changed_input_type = 'W';
-            } else if (changedInputId === 'interactive_p') {
-                changed_input_type = 'P';
-            } else {
-                return;
+            const changedElement = event.target;
+            const changed_input_type = changedElement.dataset.changed; // 'W' or 'P' from number input, or undefined for slider
+
+            if (!changed_input_type && !changedElement.classList.contains('interactive-slider')) return;
+
+            let wValue = parseFloat(interactiveWField.value) || 0;
+            let pValue = parseFloat(interactivePField.value) || 0;
+            let final_changed_type = changed_input_type;
+
+            if (changedElement.classList.contains('interactive-slider')) {
+                const targetInputId = changedElement.dataset.target;
+                const targetInput = document.getElementById(targetInputId);
+                if (targetInput) {
+                    targetInput.value = changedElement.value; // Sync slider to text input
+                    if (targetInputId === 'interactive_w') {
+                        wValue = parseFloat(targetInput.value) || 0;
+                        final_changed_type = 'W';
+                    } else if (targetInputId === 'interactive_p') {
+                        pValue = parseFloat(targetInput.value) || 0;
+                        final_changed_type = 'P';
+                    }
+                }
+            } else if (changedElement.classList.contains('interactive-input')) {
+                // Sync text input to slider
+                const sliderId = "slider_" + changed_input_type.toLowerCase();
+                const slider = document.getElementById(sliderId);
+                if (slider) {
+                    slider.value = changedElement.value;
+                }
+                final_changed_type = changed_input_type;
             }
 
-            const wValue = parseFloat(interactiveWField.value) || 0;
-            const pValue = parseFloat(interactivePField.value) || 0;
+            if (!final_changed_type) return;
+
 
             const payload = {
-                changed_input: changed_input_type,
+                changed_input: final_changed_type,
                 W_value: wValue,
                 P_value: pValue,
                 r_overall_nominal: initialROverallNominal,
@@ -230,20 +243,32 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(data => {
                 if (data.error) {
                     alert("Recalculation Error: " + data.error);
-                    if (changed_input_type === 'W' && data.new_P !== undefined) interactivePField.value = data.new_P.toFixed(0); else if (changed_input_type === 'W') interactivePField.value = pValue.toFixed(0);
-                    if (changed_input_type === 'P' && data.new_W !== undefined) interactiveWField.value = data.new_W.toFixed(0); else if (changed_input_type === 'P') interactiveWField.value = wValue.toFixed(0);
+                    // Reset the field that was just changed by user, or the one that was supposed to be calculated
+                    if (final_changed_type === 'W') { // W was changed, P was expected
+                        interactivePField.value = data.new_P !== undefined ? parseFloat(data.new_P).toFixed(0) : pValue.toFixed(0);
+                        if(document.getElementById('slider_p')) document.getElementById('slider_p').value = interactivePField.value;
+                    } else if (final_changed_type === 'P') { // P was changed, W was expected
+                        interactiveWField.value = data.new_W !== undefined ? parseFloat(data.new_W).toFixed(0) : wValue.toFixed(0);
+                        if(document.getElementById('slider_w')) document.getElementById('slider_w').value = interactiveWField.value;
+                    }
                 } else {
-                    if (changed_input_type === 'W') {
-                        interactivePField.value = data.new_P !== undefined ? data.new_P.toFixed(0) : '';
-                    } else if (changed_input_type === 'P') {
-                        interactiveWField.value = data.new_W !== undefined ? data.new_W.toFixed(0) : '';
+                    if (final_changed_type === 'W') {
+                        interactivePField.value = data.new_P !== undefined ? parseFloat(data.new_P).toFixed(0) : '';
+                        if(document.getElementById('slider_p')) document.getElementById('slider_p').value = interactivePField.value;
+                    } else if (final_changed_type === 'P') {
+                        interactiveWField.value = data.new_W !== undefined ? parseFloat(data.new_W).toFixed(0) : '';
+                        if(document.getElementById('slider_w')) document.getElementById('slider_w').value = interactiveWField.value;
                     }
 
                     if (plot1Container && data.plot1_div_html) {
                         plot1Container.innerHTML = data.plot1_div_html;
+                    } else if (plot1Container) {
+                        plot1Container.innerHTML = "<p>{{_('Plot data not available.')}}</p>";
                     }
                     if (plot2Container && data.plot2_div_html) {
                         plot2Container.innerHTML = data.plot2_div_html;
+                    } else if (plot2Container) {
+                        plot2Container.innerHTML = ""; // Or some other placeholder
                     }
                 }
             })
@@ -254,8 +279,117 @@ document.addEventListener('DOMContentLoaded', function() {
         }, 750);
     }
 
-    if (interactiveWField) interactiveWField.addEventListener('input', handleInputChange);
-    if (interactivePField) interactivePField.addEventListener('input', handleInputChange);
+    // Helper function to update a slider's max value if needed, and sync input
+    function updateSliderMaxIfNeeded(inputElement, sliderElement) {
+        const numericValue = parseFloat(inputElement.value);
+        if (!isNaN(numericValue)) {
+            // Adjust min if value goes below (though our inputs have min="0")
+            if (numericValue < parseFloat(sliderElement.min)) {
+                inputElement.value = sliderElement.min;
+                sliderElement.value = sliderElement.min; // Sync slider to corrected input
+                // No further max adjustment needed if value was clamped to min
+                return;
+            }
+            // Adjust max if value goes above
+            if (numericValue > parseFloat(sliderElement.max)) {
+                sliderElement.max = Math.ceil(numericValue * 1.2 / (sliderElement.step || 1)) * (sliderElement.step || 1);
+            }
+            // Sync slider to current input value (which might have been clamped or is within new max)
+            sliderElement.value = inputElement.value;
+        }
+    }
+
+    // Debounced AJAX call logic
+    function makeAjaxCall(changedParamType) { // changedParamType is 'W' or 'P'
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            const wValue = parseFloat(interactiveWField.value) || 0;
+            const pValue = parseFloat(interactivePField.value) || 0;
+
+            const payload = {
+                changed_input: changedParamType,
+                W_value: wValue,
+                P_value: pValue,
+                r_overall_nominal: initialROverallNominal,
+                i_overall: initialIOverall,
+                total_duration_from_periods: initialTotalDuration,
+                withdrawal_time_str: initialWithdrawalTimeStr,
+                fixed_desired_final_value: initialDesiredFinalValue,
+                rates_periods_summary: initialRatesPeriods,
+                one_off_events_summary: initialOneOffEvents
+            };
+
+            fetch("{{ url_for('wizard_bp.wizard_recalculate_interactive') }}", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken
+                },
+                body: JSON.stringify(payload)
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    alert("Recalculation Error: " + data.error);
+                    // Reset the field that was supposed to be calculated, to the value sent by server (original value)
+                    if (changedParamType === 'W' && data.new_P !== undefined) {
+                         interactivePField.value = parseFloat(data.new_P).toFixed(0);
+                         updateSliderMaxIfNeeded(interactivePField, sliderP); // Update max just in case
+                    } else if (changedParamType === 'P' && data.new_W !== undefined) {
+                         interactiveWField.value = parseFloat(data.new_W).toFixed(0);
+                         updateSliderMaxIfNeeded(interactiveWField, sliderW);
+                    }
+                } else {
+                    // Update the OTHER input field and its slider's max if needed
+                    if (changedParamType === 'W') { // W was sent, P is new
+                        interactivePField.value = data.new_P !== undefined ? parseFloat(data.new_P).toFixed(0) : '';
+                        updateSliderMaxIfNeeded(interactivePField, sliderP);
+                    } else if (changedParamType === 'P') { // P was sent, W is new
+                        interactiveWField.value = data.new_W !== undefined ? parseFloat(data.new_W).toFixed(0) : '';
+                        updateSliderMaxIfNeeded(interactiveWField, sliderW);
+                    }
+
+                    // Update plots
+                    if (plot1Container && data.plot1_div_html) {
+                        plot1Container.innerHTML = data.plot1_div_html;
+                    } else if (plot1Container) {
+                        plot1Container.innerHTML = "<p>{{_('Plot data not available.')}}</p>";
+                    }
+                    if (plot2Container && data.plot2_div_html) {
+                        plot2Container.innerHTML = data.plot2_div_html;
+                    } else if (plot2Container) {
+                        plot2Container.innerHTML = "";
+                    }
+                }
+            })
+            .catch(error => {
+                console.error('Error during interactive recalculation:', error);
+                alert('An error occurred while recalculating. Please check the console.');
+            });
+        }, 750);
+    }
+
+    const sliderW = document.getElementById('slider_w');
+    const sliderP = document.getElementById('slider_p');
+
+    interactiveWField.addEventListener('input', function() {
+        updateSliderMaxIfNeeded(this, sliderW); // Update slider max based on input, and sync its value
+        makeAjaxCall('W');
+    });
+    sliderW.addEventListener('input', function() {
+        interactiveWField.value = this.value; // Sync input to this slider
+        // No need to call updateSliderMaxIfNeeded from slider input, as slider is bound by its own max
+        makeAjaxCall('W');
+    });
+
+    interactivePField.addEventListener('input', function() {
+        updateSliderMaxIfNeeded(this, sliderP); // Update slider max based on input, and sync its value
+        makeAjaxCall('P');
+    });
+    sliderP.addEventListener('input', function() {
+        interactivePField.value = this.value; // Sync input to this slider
+        makeAjaxCall('P');
+    });
 
     // Initial console log for debugging data availability
     // console.log("Fixed params for JS:", {initialROverallNominal, initialIOverall, initialTotalDuration, initialWithdrawalTimeStr, initialDesiredFinalValue, initialRatesPeriods, initialOneOffEvents, csrfToken});

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -95,7 +95,50 @@ class TestWizardForms(unittest.TestCase):
             self.assertFalse(form.validate())
             self.assertIn('return_rate', form.errors)
 
-    def test_one_offs_form_valid(self):
+
+    # This test was for when itemized fields were DataRequired. Now they are Optional.
+    # Renaming and adapting to test that annual_expenses is still DataRequired.
+    def test_expenses_form_invalid_missing_annual_expenses(self): # Renamed
+        with app.test_request_context('/'):
+            from werkzeug.datastructures import MultiDict
+            form_data = {
+                # 'annual_expenses' is missing
+                'housing': '15000', 'food': '6000',
+                'transportation': '5000', 'utilities': '3000', 'personal_care': '2000',
+                'entertainment': '4000', 'healthcare': '3000', 'other_expenses': '1000'
+            }
+            form = ExpensesForm(formdata=MultiDict(form_data)) # Using formdata for MultiDict
+            self.assertFalse(form.validate())
+            self.assertIn('annual_expenses', form.errors)
+
+    def test_expenses_form_valid_with_only_annual_expenses(self):
+        with app.test_request_context('/'):
+            from werkzeug.datastructures import MultiDict
+            form_data = {
+                'annual_expenses': '50000',
+                'housing': '',
+                'food': None,
+                # other itemized fields omitted
+            }
+            form = ExpensesForm(formdata=MultiDict(form_data)) # Using formdata for MultiDict
+            self.assertTrue(form.validate(), msg=form.errors)
+
+    # Original test_expenses_form_invalid_number_range might have tested annual_expenses.
+    # Let's keep it if it did, or ensure one exists for annual_expenses.
+    # This one will specifically test an itemized field's number range.
+    def test_expenses_form_invalid_itemized_number_range(self):
+        with app.test_request_context('/'):
+            from werkzeug.datastructures import MultiDict
+            form_data = {
+                'annual_expenses': '50000',
+                'housing': '-100',
+            }
+            form = ExpensesForm(formdata=MultiDict(form_data))
+            self.assertFalse(form.validate())
+            self.assertIn('housing', form.errors)
+
+
+    def test_rates_form_valid_with_new_fields(self): # Renamed from test_rates_form_valid
         with app.test_request_context('/'):
             form_wtforms_data = {
                 'large_expenses': [{'year': 2025, 'amount': 10000.0, 'description': 'Car'}],


### PR DESCRIPTION
This commit introduces major enhancements to the FIRE wizard and its results page:

1.  **Optional Itemized Expenses (Wizard Step 1):**
    - In `ExpensesForm` (`project/forms.py`), all itemized expense fields (housing, food, etc.) now use `Optional()` validators instead of `DataRequired()`. `NumberRange(min=0)` is retained.
    - The main `annual_expenses` field remains `DataRequired()`.
    - This allows you to proceed by providing only the total annual expenses if you prefer not to itemize.
    - Unit tests for `ExpensesForm` in `tests/test_wizard.py` have been updated to reflect this change.

2.  **Restructured Results Page (`wizard_results.html`):**
    - **Dual Plot Sets:** - The page now displays two sets of plots side-by-side. - The first set shows plots for the *original* wizard calculation (using distinct IDs like `original_plot1_container`). These are static. - The "Interactive What-If Analysis" card now contains its own set of plot containers (`interactive_plot1_container`, `interactive_plot2_container`) which are updated dynamically.
    - **Sliders for Interactive Inputs:**
        - Range sliders (`<input type="range">`) have been added alongside the number input fields for "Annual Expenses (W)" and "Target Portfolio (P)" within the "Interactive What-If Analysis" section.

3.  **Updated Backend Plot Generation for Color Schemes:**
    - In `project/wizard_routes.py`: - Plots generated by `wizard_calculate_step` (for original results) now use a distinct color (e.g., blue) for their main traces. - Plots generated by the `/wizard/recalculate_interactive` AJAX endpoint (for what-if analysis) use a different color (e.g., green) and have "(What-If)" appended to their titles/trace names for clarity.

4.  **Enhanced Client-Side JavaScript (`wizard_results.html`):**
    - **Slider-Text Box Synchronization:** JavaScript now synchronizes the values of the new range sliders with their corresponding number input fields. Changing one updates the other.
    - **Dynamic Slider Max Values:** The `max` attribute of the sliders is dynamically adjusted if you enter a value in the text input that exceeds the slider's current maximum, or if a recalculated value from AJAX does so.
    - **Targeted Plot Updates:** The AJAX success callback now correctly updates the content of the new `interactive_plot1_container` and `interactive_plot2_container` with the what-if plot HTML. The original plots remain static.
    - Debouncing and CSRF token handling for AJAX calls are maintained.

These changes provide a more flexible data entry experience in the wizard, a richer interactive analysis capability on the results page with clearer visual distinction between original and what-if scenarios, and an improved user interface with sliders.