### PR TITLE
fix: Correct Jinja2 filter for JS string embedding

### DIFF
--- a/templates/wizard_results.html
+++ b/templates/wizard_results.html
@@ -320,8 +320,8 @@ document.addEventListener('DOMContentLoaded', function() {
         sliderP.addEventListener('input', function() { interactivePField.value = this.value; makeAjaxCall('P'); });
     } else { logDebug("P input field or slider not found for event listener setup."); }
 
-    const initialErrorMessage = "{{ error_message | default('') | escapejs }}";
-    const initialPDisplay = "{{ P_calculated_display | default('') | escapejs }}";
+    const initialErrorMessage = {{ error_message | default('') | tojson | safe }};
+    const initialPDisplay = {{ P_calculated_display | default('') | tojson | safe }};
     logDebug(`Initial page error_message: '${initialErrorMessage}'`);
     logDebug(`Initial P_calculated_display: '${initialPDisplay}'`);
 


### PR DESCRIPTION
Replaces the incorrect `escapejs` filter with `tojson | safe` in `templates/wizard_results.html`.

The `escapejs` filter is not a standard Jinja2 filter and was causing a `TemplateAssertionError`. The `tojson | safe` combination correctly and safely formats server-side strings for embedding as JavaScript string literals.

This change affects the initialization of `initialErrorMessage` and `initialPDisplay` JavaScript variables, ensuring they are populated correctly with values from the template context.