### PR TITLE
style: Add debug CSS to interactive plot containers

### DIFF
--- a/templates/wizard_results.html
+++ b/templates/wizard_results.html
@@ -112,10 +112,10 @@
 
       {# New Plot Containers for Interactive Analysis (Side-by-Side) #}
       <div class="row mt-4">
-        <div id="interactive_plot1_container" class="col-md-6 mb-3">
+        <div id="interactive_plot1_container" class="col-md-6 mb-3" style="min-height: 400px; border: 2px dashed red; padding: 5px; margin-top: 10px;">
           <p>{{_("Interactive plots will appear here after adjustment.")}}</p>
         </div>
-        <div id="interactive_plot2_container" class="col-md-6 mb-3">
+        <div id="interactive_plot2_container" class="col-md-6 mb-3" style="min-height: 400px; border: 2px dashed blue; padding: 5px; margin-top: 10px;">
           {# This will be populated by JS. #}
         </div>
       </div>


### PR DESCRIPTION
To help diagnose issues with interactive plots not appearing on the wizard results page, this commit adds inline CSS styles to the `interactive_plot1_container` and `interactive_plot2_container` divs in `templates/wizard_results.html`.

The added styles include:
- `min-height: 400px` to ensure the containers have a defined height.
- `border: 2px dashed red` (for plot 1) and `border: 2px dashed blue` (for plot 2) to make the containers visually identifiable on the page.
- `padding: 5px` and `margin-top: 10px` for basic spacing.

This change is intended as a diagnostic aid to determine if the plot containers are being rendered correctly and occupying space, even if the Plotly charts themselves fail to render.