### PR TITLE
fix: Improve Plotly chart rendering by ensuring container size and la…

### DIFF
--- a/project/wizard_routes.py
+++ b/project/wizard_routes.py
@@ -265,7 +265,7 @@ def wizard_calculate_step():
                             marker=dict(size=10, color='red' if event['amount'] < 0 else 'green', symbol='triangle-down' if event['amount'] < 0 else 'triangle-up'),
                             name=f"One-off: {event['amount']:.0f}"
                         ))
-                fig_balance.update_layout(title="Portfolio Balance Over Time", xaxis_title="Year", yaxis_title="Portfolio Balance", legend_title_text="Legend")
+                fig_balance.update_layout(title="Portfolio Balance Over Time", xaxis_title="Year", yaxis_title="Portfolio Balance", legend_title_text="Legend", autosize=True)
                 plot1_spec = {'data': [trace.to_plotly_json() for trace in fig_balance.data], 'layout': fig_balance.layout.to_plotly_json()}
             except Exception as e_plot1:
                 current_app.logger.error(f"Error generating balance plot spec: {e_plot1}", exc_info=True)
@@ -285,7 +285,7 @@ def wizard_calculate_step():
                     if total_T_sim > 0: # Log only if there was an actual mismatch with expected withdrawals
                          current_app.logger.warning(f"Original withdrawal plot data length mismatch: x_data (len {len(x_withdraw_years)} based on sim_years), y_data (len {total_T_sim} from sim_withdrawals)")
 
-                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount", legend_title_text="Legend")
+                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount", legend_title_text="Legend", autosize=True)
                 plot2_spec = {'data': [trace.to_plotly_json() for trace in fig_withdrawals.data], 'layout': fig_withdrawals.layout.to_plotly_json()}
             except Exception as e_plot2:
                 current_app.logger.error(f"Error generating withdrawal plot spec: {e_plot2}", exc_info=True)
@@ -468,7 +468,7 @@ def wizard_recalculate_interactive():
                             marker=dict(size=10, color='red' if event['amount'] < 0 else 'green', symbol='triangle-down' if event['amount'] < 0 else 'triangle-up'),
                             name=f"One-off: {event['amount']:.0f}"
                         ))
-                fig_balance.update_layout(title="Portfolio Balance Over Time (What-If)", xaxis_title="Year", yaxis_title="Portfolio Balance")
+                fig_balance.update_layout(title="Portfolio Balance Over Time (What-If)", xaxis_title="Year", yaxis_title="Portfolio Balance", autosize=True)
                 plot1_spec_interactive = {'data': [trace.to_plotly_json() for trace in fig_balance.data], 'layout': fig_balance.layout.to_plotly_json()}
             except Exception as e_plot1_ia:
                 current_app.logger.error(f"Error generating interactive balance plot spec: {e_plot1_ia}", exc_info=True)
@@ -487,7 +487,7 @@ def wizard_recalculate_interactive():
                     if total_T_sim_ia > 0:
                          current_app.logger.warning(f"Interactive withdrawal plot data length mismatch: x_data (len {len(x_withdraw_years_ia)} based on sim_years), y_data (len {total_T_sim_ia} from sim_withdrawals)")
 
-                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time (What-If)", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount")
+                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time (What-If)", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount", autosize=True)
                 plot2_spec_interactive = {'data': [trace.to_plotly_json() for trace in fig_withdrawals.data], 'layout': fig_withdrawals.layout.to_plotly_json()}
             except Exception as e_plot2_ia:
                 current_app.logger.error(f"Error generating interactive withdrawal plot spec: {e_plot2_ia}", exc_info=True)

--- a/templates/wizard_results.html
+++ b/templates/wizard_results.html
@@ -65,8 +65,8 @@
   <h3 class="mt-4 mb-3 text-center">{{_("Original Calculation Plots")}}</h3>
   {% if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" %}
     <div class="row">
-      <div id="original_plot1_container" class="col-md-6 mb-3"></div>
-      <div id="original_plot2_container" class="col-md-6 mb-3"></div>
+      <div id="original_plot1_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
+      <div id="original_plot2_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
     </div>
   {% else %}
     <p class="text-center">{{_("Original plots not available due to calculation error or infeasible scenario.")}}</p>
@@ -108,8 +108,8 @@
 
       {# New Plot Containers for Interactive Analysis (Side-by-Side) #}
       <div class="row mt-4">
-        <div id="interactive_plot1_container" class="col-md-6 mb-3"></div>
-        <div id="interactive_plot2_container" class="col-md-6 mb-3"></div>
+        <div id="interactive_plot1_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
+        <div id="interactive_plot2_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
…yout autosize

Addresses an issue where Plotly charts on the wizard results page were appearing "squished" or not properly sized.

Changes include:

1.  **Added `min-height` to Plot Containers (`wizard_results.html`):**
    - Applied an inline style `min-height: 400px;` (and a light diagnostic border) to all four plot container divs (`original_plot1_container`, `original_plot2_container`, `interactive_plot1_container`, `interactive_plot2_container`).
    - This ensures that the HTML containers have a defined vertical space for Plotly to render the charts into.

2.  **Set `autosize=True` in Plotly Layouts (Backend):**
    - In `project/wizard_routes.py`, modified both the `wizard_calculate_step` and `wizard_recalculate_interactive` functions.
    - When calling `update_layout()` for the Plotly figure objects (`fig_balance`, `fig_withdrawals`), `autosize=True` is now explicitly included. This instructs Plotly to adjust the plot dimensions to fit their containers.

These changes should provide adequate space and instruction for Plotly to render the charts correctly, resolving the sizing issues.