### PR TITLE
refactor: Reduce verbosity of JavaScript debug logging

### DIFF
--- a/templates/wizard_results.html
+++ b/templates/wizard_results.html
@@ -332,7 +332,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let debounceTimer;
     function makeAjaxCall(changedParamType) {
         clearTimeout(debounceTimer);
-        logDebug(`makeAjaxCall (debounced) for: ${changedParamType}. Setting timeout.`);
+        // logDebug(`makeAjaxCall (debounced) for: ${changedParamType}. Setting timeout.`); // Removed for less verbosity
         debounceTimer = setTimeout(() => {
             logDebug(`Debounced AJAX call executing for: ${changedParamType}`);
             performAjaxCalculation(changedParamType);


### PR DESCRIPTION
This commit refines the client-side JavaScript debugging on the wizard results page (`templates/wizard_results.html`).

- Removed a verbose log message (`makeAjaxCall (debounced) for: ... Setting timeout.`) from the `makeAjaxCall` function. This message was logged on every input event before the debounce period and was deemed too noisy now that the core functionality is stable.
- The more informative log message (`Debounced AJAX call executing for: ...`) that appears when the AJAX call actually proceeds after the debounce is retained.
- The main on-page debug output div (`interactive_debug_output`) and other `logDebug` calls remain in place for now, as they might still be useful.

This change makes the on-page debug output less cluttered.