### PR TITLE
refactor: Display plots in side-by-side card-based panels

### DIFF
--- a/templates/wizard_results.html
+++ b/templates/wizard_results.html
@@ -64,9 +64,23 @@
   {# --- Static Original Calculation Plots (Side-by-Side) --- #}
   <h3 class="mt-4 mb-3 text-center">{{_("Original Calculation Plots")}}</h3>
   {% if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" %}
-    <div class="row">
-      <div id="original_plot1_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
-      <div id="original_plot2_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
+    <div class="row mb-4"> {# Row for the pair of original plot panels #}
+      <div class="col-md-6">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title text-center">{{_("Original Portfolio Balance")}}</h5>
+            <div id="original_plot1_container" style="min-height: 350px;"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title text-center">{{_("Original Annual Withdrawals")}}</h5>
+            <div id="original_plot2_container" style="min-height: 350px;"></div>
+          </div>
+        </div>
+      </div>
     </div>
   {% else %}
     <p class="text-center">{{_("Original plots not available due to calculation error or infeasible scenario.")}}</p>
@@ -109,9 +123,23 @@
       {# The old <small> text was here, now removed. #}
 
       {# New Plot Containers for Interactive Analysis (Side-by-Side) #}
-      <div class="row mt-4">
-        <div id="interactive_plot1_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
-        <div id="interactive_plot2_container" class="col-md-6 mb-3" style="min-height: 400px; border: 1px solid #eee;"></div>
+      <div class="row mt-4"> {# Row for the pair of interactive plot panels #}
+        <div class="col-md-6">
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title text-center">{{_("Interactive Portfolio Balance")}}</h5>
+              <div id="interactive_plot1_container" style="min-height: 350px;"></div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title text-center">{{_("Interactive Annual Withdrawals")}}</h5>
+              <div id="interactive_plot2_container" style="min-height: 350px;"></div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This commit refactors the layout of plots on the wizard results page (`templates/wizard_results.html`) to address alignment issues and improve visual organization, based on your feedback.

Key changes:

1.  **Card-Based Panels for Plots:**
    - Each of the four plots (original balance/withdrawal, interactive balance/withdrawal) is now rendered within its own Bootstrap card structure (`<div class="card">...</div>`).
    - Each card includes a title (e.g., "Original Portfolio Balance", "Interactive Annual Withdrawals") within the `card-body`.
    - The plot container divs (e.g., `original_plot1_container`) are placed inside this card structure and maintain their `min-height` style (e.g., 350px). Explicit border styles on these inner divs were removed as the card now provides the visual boundary.

2.  **Side-by-Side Arrangement:**
    - Each pair of plot cards (the two original plots, and the two interactive plots) is placed within a Bootstrap `div class="row"`, with each card occupying a `div class="col-md-6"`.
    - This arranges the plots side-by-side in two distinct pairs:
        - Original Plots: [Card: Balance] [Card: Withdrawals]
        - Interactive Plots: [Card: Balance] [Card: Withdrawals] (below the interactive input/slider section).

3.  **JavaScript Targeting Verified:**
    - I confirmed that the existing JavaScript logic for rendering and resizing plots correctly targets the plot container divs by their IDs, even with the new nested card structure. No changes to the JavaScript targeting logic were necessary for this layout update.

This new panel-based layout provides better visual separation and structure for the plots, aiming to resolve previous alignment and "squished" appearance issues by giving each plot a clearly defined panel within the side-by-side responsive grid.