### PR TITLE
fix: Remove extraneous marker causing SyntaxError in wizard_routes.py

### DIFF
--- a/project/wizard_routes.py
+++ b/project/wizard_routes.py
@@ -463,5 +463,3 @@ def export_csv():
         mimetype="text/csv",
         headers={"Content-Disposition": "attachment;filename=fire_calculation_results.csv"}
     )
-
-[end of project/wizard_routes.py]


### PR DESCRIPTION
Removes an erroneous line `[end of project/wizard_routes.py]` that was accidentally included at the end of the
`project/wizard_routes.py` file. This marker was causing a `SyntaxError` when your application was run.

This commit cleans up the file to ensure it contains only valid Python code.