### PR TITLE
fix: Enable jinja2.ext.do extension for Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from babel.numbers import format_currency
 app = Flask(__name__)
 app.testing = True # Ensure testing mode is enabled when app is imported
 csrf = CSRFProtect(app)
+app.jinja_env.add_extension('jinja2.ext.do') # <-- ADD THIS LINE
 
 # Basic app logging
 if not app.debug:


### PR DESCRIPTION
Enables the `jinja2.ext.do` extension in the Flask application's Jinja2 environment (`app.py`).

This is necessary to allow the use of the `{% do %}` template tag, which was recently used in `templates/wizard_results.html` for updating a dictionary (`query_params.update(...)`) without assigning the `None` result to a variable.

Failure to enable this extension resulted in a
`jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'do'`. This commit resolves that error.