### PR TITLE
fix: Correct gettext usage for translations in wizard routes

### DIFF
--- a/project/wizard_routes.py
+++ b/project/wizard_routes.py
@@ -12,10 +12,12 @@ import io
 from fpdf import FPDF
 import tempfile
 import os
+from flask_babel import gettext # Added for direct gettext usage
 
 
 wizard_bp = Blueprint('wizard_bp', __name__, template_folder='../templates', url_prefix='/wizard')
 
+# ... (all other routes: wizard_expenses_step, wizard_rates_step, wizard_one_offs_step, wizard_summary_step, wizard_calculate_step, wizard_recalculate_interactive - remain unchanged) ...
 @wizard_bp.route('/expenses', methods=['GET', 'POST'])
 def wizard_expenses_step():
     form = ExpensesForm(request.form if request.method == 'POST' else None)
@@ -84,7 +86,7 @@ def wizard_summary_step():
 @wizard_bp.route('/calculate', methods=['POST'])
 def wizard_calculate_step():
     if not all(key in session for key in ['wizard_expenses', 'wizard_rates', 'wizard_one_offs']):
-        flash("Session data is incomplete. Please restart the wizard.", "error")
+        flash(gettext("Session data is incomplete. Please restart the wizard."), "error") # Changed to gettext
         return redirect(url_for('wizard_bp.wizard_expenses_step'))
 
     expenses_data = session.get('wizard_expenses', {})
@@ -135,8 +137,8 @@ def wizard_calculate_step():
                 one_off_events=one_off_events
             )
             if P_calculated is None or P_calculated == float('inf') or P_calculated < 0:
-                error_message = "Could not calculate a suitable portfolio (FIRE number) for the given expenses and market conditions. Inputs may be unrealistic (e.g., expenses too high, returns too low for the duration)."
-                P_calculated_display = "Not Feasible"
+                error_message = gettext("Could not calculate a suitable portfolio (FIRE number) for the given expenses and market conditions. Inputs may be unrealistic (e.g., expenses too high, returns too low for the duration).") # Changed
+                P_calculated_display = gettext("Not Feasible") # Changed
             else:
                 P_calculated_display = f"{P_calculated:,.2f}"
                 current_app.logger.debug(f"Calling annual_simulation with PV={P_calculated}, W_initial={W_actual_for_P_calc}, withdrawal_time={withdrawal_time}, desired_final_value={desired_final_value}")
@@ -151,14 +153,14 @@ def wizard_calculate_step():
                 current_app.logger.debug(f"annual_simulation returned: sim_withdrawals (type: {type(sim_withdrawals)}, len: {len(sim_withdrawals) if sim_withdrawals is not None else 'None'}): {str(sim_withdrawals)[:200]}")
         except Exception as e:
             current_app.logger.error(f"Error during financial calculation: {e}", exc_info=True)
-            error_message = "An unexpected error occurred during financial calculations."
-            P_calculated_display = "Error"
+            error_message = gettext("An unexpected error occurred during financial calculations.") # Changed
+            P_calculated_display = gettext("Error") # Changed
             sim_years, sim_balances, sim_withdrawals = [], [], []
 
         if error_message:
-            flash(error_message, "error")
+            flash(error_message, "error") # error_message is already translated
             return render_template('wizard_results.html',
-                                   title="Calculation Error", error_message=error_message,
+                                   title=gettext("Calculation Error"), error_message=error_message, # Changed
                                    P_calculated_display=P_calculated_display, P_raw=0.0, W=W,
                                    W_display=f"{W:,.2f}", r_overall_nominal=r_overall_nominal,
                                    i_overall=i_overall, rates_periods_summary=rates_periods,
@@ -177,7 +179,7 @@ def wizard_calculate_step():
                 fig_balance = go.Figure()
                 x_balance_years = list(sim_years)
                 y_balances = list(sim_balances)
-                fig_balance.add_trace(go.Scatter(x=x_balance_years, y=y_balances, mode='lines+markers', name="Portfolio Balance", line=dict(color='blue')))
+                fig_balance.add_trace(go.Scatter(x=x_balance_years, y=y_balances, mode='lines+markers', name=gettext("Portfolio Balance"), line=dict(color='blue'))) # Changed
                 sim_balances_list = list(sim_balances)
                 for event in one_off_events:
                     if 0 <= event['year'] < len(sim_balances_list):
@@ -185,9 +187,9 @@ def wizard_calculate_step():
                         fig_balance.add_trace(go.Scatter(
                             x=[event['year']], y=[float(event_y_approx)], mode='markers',
                             marker=dict(size=10, color='red' if event['amount'] < 0 else 'green', symbol='triangle-down' if event['amount'] < 0 else 'triangle-up'),
-                            name=f"One-off: {event['amount']:.0f}"
+                            name=f"{gettext('One-off')}: {event['amount']:.0f}" # Changed
                         ))
-                fig_balance.update_layout(title="Portfolio Balance Over Time", xaxis_title="Year", yaxis_title="Portfolio Balance", legend_title_text="Legend", autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2))
+                fig_balance.update_layout(title=gettext("Portfolio Balance Over Time"), xaxis_title=gettext("Year"), yaxis_title=gettext("Portfolio Balance"), legend_title_text=gettext("Legend"), autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2)) # Changed
                 plot1_spec = {'data': [trace.to_plotly_json() for trace in fig_balance.data], 'layout': fig_balance.layout.to_plotly_json()}
             except Exception as e_plot1:
                 current_app.logger.error(f"Error generating balance plot spec: {e_plot1}", exc_info=True)
@@ -199,17 +201,17 @@ def wizard_calculate_step():
                 x_withdraw_years = list(sim_years[1 : total_T_sim + 1]) if total_T_sim > 0 and len(sim_years) >= (total_T_sim + 1) else []
                 y_withdrawals = list(sim_withdrawals)
                 if total_T_sim > 0 and len(x_withdraw_years) == total_T_sim :
-                    fig_withdrawals.add_trace(go.Scatter(x=x_withdraw_years, y=y_withdrawals, mode='lines+markers', name="Annual Withdrawal", line=dict(color='blue')))
+                    fig_withdrawals.add_trace(go.Scatter(x=x_withdraw_years, y=y_withdrawals, mode='lines+markers', name=gettext("Annual Withdrawal"), line=dict(color='blue'))) # Changed
                 else:
-                    fig_withdrawals.add_trace(go.Scatter(x=[], y=[], mode='lines+markers', name="Annual Withdrawal", line=dict(color='blue')))
+                    fig_withdrawals.add_trace(go.Scatter(x=[], y=[], mode='lines+markers', name=gettext("Annual Withdrawal"), line=dict(color='blue'))) # Changed
                     if total_T_sim > 0:
                          current_app.logger.warning(f"Original withdrawal plot data length mismatch: x_data (len {len(x_withdraw_years)}), y_data (len {total_T_sim})")
-                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount", legend_title_text="Legend", autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2))
+                fig_withdrawals.update_layout(title=gettext("Annual Withdrawals Over Time"), xaxis_title=gettext("Year"), yaxis_title=gettext("Annual Withdrawal Amount"), legend_title_text=gettext("Legend"), autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2)) # Changed
                 plot2_spec = {'data': [trace.to_plotly_json() for trace in fig_withdrawals.data], 'layout': fig_withdrawals.layout.to_plotly_json()}
             except Exception as e_plot2:
                 current_app.logger.error(f"Error generating withdrawal plot spec: {e_plot2}", exc_info=True)
 
-        table_rows = []
+        table_rows = [] # table_rows are for display, not directly translatable data
         if sim_withdrawals is not None and len(sim_withdrawals) > 0:
             total_T_from_sim = len(sim_withdrawals)
             if (sim_years is not None and len(sim_years) == (total_T_from_sim + 1) and
@@ -237,30 +239,25 @@ def wizard_calculate_step():
 
         W_display = f"{W:,.2f}"
 
-        # Ensure all numeric data for session is Python native type
         py_W = float(W)
         py_P_calculated = float(P_calculated) if isinstance(P_calculated, (int, float)) and P_calculated is not None and P_calculated != float('inf') else None
         py_r_overall_nominal = float(r_overall_nominal)
         py_i_overall = float(i_overall)
         py_total_duration_from_periods = int(total_duration_from_periods)
         py_desired_final_value = float(desired_final_value)
-
         py_sim_years = [int(y) for y in sim_years] if sim_years is not None else []
         py_sim_balances = [float(b) for b in sim_balances] if sim_balances is not None else []
         py_sim_withdrawals = [float(w) for w in sim_withdrawals] if sim_withdrawals is not None else []
 
         export_data = {
-            'W': py_W,
-            'P_calculated': py_P_calculated,
-            'r_overall_nominal': py_r_overall_nominal,
-            'i_overall': py_i_overall,
+            'W': py_W, 'P_calculated': py_P_calculated,
+            'r_overall_nominal': py_r_overall_nominal, 'i_overall': py_i_overall,
             'total_duration_from_periods': py_total_duration_from_periods,
-            'withdrawal_time_str': withdrawal_time_str, # String, already fine
+            'withdrawal_time_str': withdrawal_time_str,
             'desired_final_value': py_desired_final_value,
-            'rates_periods_summary': rates_periods, # Assumed list of dicts with Python types
-            'one_off_events_summary': one_off_events, # Assumed list of dicts with Python types
-            'sim_years': py_sim_years,
-            'sim_balances': py_sim_balances,
+            'rates_periods_summary': rates_periods,
+            'one_off_events_summary': one_off_events,
+            'sim_years': py_sim_years, 'sim_balances': py_sim_balances,
             'sim_withdrawals': py_sim_withdrawals
         }
         session['last_calc_export_data'] = export_data
@@ -271,7 +268,7 @@ def wizard_calculate_step():
         current_app.logger.debug("Wizard session data cleared after successful calculation.")
 
         return render_template('wizard_results.html',
-                               title="Calculation Results",
+                               title=gettext("Calculation Results"), # Changed
                                P_calculated_display=P_calculated_display,
                                P_raw=P_calculated if P_calculated is not None and P_calculated != float('inf') else 0.0,
                                W_display=W_display, W=W,
@@ -288,7 +285,7 @@ def wizard_calculate_step():
                               )
     except Exception as e:
         current_app.logger.error(f"Error during data transformation in wizard: {e}", exc_info=True)
-        flash("An error occurred preparing data for calculation. Please check your inputs.", "error")
+        flash(gettext("An error occurred preparing data for calculation. Please check your inputs."), "error") # Changed
         return redirect(url_for('wizard_bp.wizard_summary_step'))
 
 @wizard_bp.route('/recalculate_interactive', methods=['POST'])
@@ -296,7 +293,7 @@ def wizard_recalculate_interactive():
     try:
         data = request.get_json()
         if not data:
-            return jsonify({'error': 'Invalid request: No JSON data received.'}), 400
+            return jsonify({'error': gettext('Invalid request: No JSON data received.')}), 400 # Changed
 
         changed_input = data.get('changed_input')
         W_input_val = float(data.get('W_value', 0))
@@ -331,7 +328,7 @@ def wizard_recalculate_interactive():
                 one_off_events=one_off_events_for_calc
             )
             if P_recalculated is None or P_recalculated == float('inf') or P_recalculated < 0:
-                error_msg_recalc = "Could not calculate a suitable portfolio for the new expenses."
+                error_msg_recalc = gettext("Could not calculate a suitable portfolio for the new expenses.") # Changed
                 new_P_calculated = P_input_val; new_W_calculated = W_to_use
             else:
                 new_P_calculated = P_recalculated; new_W_calculated = W_to_use
@@ -347,7 +344,7 @@ def wizard_recalculate_interactive():
                 one_off_events=one_off_events_for_calc
             )
             if W_recalculated is None or W_recalculated < 0:
-                error_msg_recalc = "Could not calculate a sustainable withdrawal for the new portfolio."
+                error_msg_recalc = gettext("Could not calculate a sustainable withdrawal for the new portfolio.") # Changed
                 new_W_calculated = W_input_val; new_P_calculated = P_to_use
             else:
                 new_W_calculated = W_recalculated; new_P_calculated = P_to_use
@@ -356,9 +353,9 @@ def wizard_recalculate_interactive():
                     rates_periods=rates_periods_for_calc, one_off_events=one_off_events_for_calc
                 )
         else:
-            return jsonify({'error': 'Invalid changed_input value.'}), 400
+            return jsonify({'error': gettext('Invalid changed_input value.')}), 400 # Changed
 
-        if error_msg_recalc:
+        if error_msg_recalc: # error_msg_recalc is already translated
             return jsonify({'error': error_msg_recalc, 'new_W': new_W_calculated, 'new_P': new_P_calculated, 'plot1_spec': None, 'plot2_spec': None }), 200
 
         plot1_spec_interactive = None
@@ -369,7 +366,7 @@ def wizard_recalculate_interactive():
                 fig_balance = go.Figure()
                 x_balance_years_ia = list(sim_years)
                 y_balances_ia = list(sim_balances)
-                fig_balance.add_trace(go.Scatter(x=x_balance_years_ia, y=y_balances_ia, mode='lines+markers', name="Portfolio Balance (What-If)", line=dict(color='green')))
+                fig_balance.add_trace(go.Scatter(x=x_balance_years_ia, y=y_balances_ia, mode='lines+markers', name=gettext("Portfolio Balance (What-If)"), line=dict(color='green'))) # Changed
                 sim_balances_list_ia = list(sim_balances)
                 for event in one_off_events_for_calc:
                     if 0 <= event['year'] < len(sim_balances_list_ia):
@@ -377,9 +374,9 @@ def wizard_recalculate_interactive():
                         fig_balance.add_trace(go.Scatter(
                             x=[event['year']], y=[float(event_y_approx)], mode='markers',
                             marker=dict(size=10, color='red' if event['amount'] < 0 else 'green', symbol='triangle-down' if event['amount'] < 0 else 'triangle-up'),
-                            name=f"One-off: {event['amount']:.0f}"
+                            name=f"{gettext('One-off')}: {event['amount']:.0f}" # Changed
                         ))
-                fig_balance.update_layout(title="Portfolio Balance Over Time (What-If)", xaxis_title="Year", yaxis_title="Portfolio Balance", autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2))
+                fig_balance.update_layout(title=gettext("Portfolio Balance Over Time (What-If)"), xaxis_title=gettext("Year"), yaxis_title=gettext("Portfolio Balance"), autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2)) # Changed
                 plot1_spec_interactive = {'data': [trace.to_plotly_json() for trace in fig_balance.data], 'layout': fig_balance.layout.to_plotly_json()}
             except Exception as e_plot1_ia:
                 current_app.logger.error(f"Error generating interactive balance plot spec: {e_plot1_ia}", exc_info=True)
@@ -391,13 +388,13 @@ def wizard_recalculate_interactive():
                 x_withdraw_years_ia = list(sim_years[1 : total_T_sim_ia + 1]) if total_T_sim_ia > 0 and len(sim_years) >= (total_T_sim_ia + 1) else []
                 y_withdrawals_ia = list(sim_withdrawals)
                 if total_T_sim_ia > 0 and len(x_withdraw_years_ia) == total_T_sim_ia:
-                    fig_withdrawals.add_trace(go.Scatter(x=x_withdraw_years_ia, y=y_withdrawals_ia, mode='lines+markers', name="Annual Withdrawal (What-If)", line=dict(color='green')))
+                    fig_withdrawals.add_trace(go.Scatter(x=x_withdraw_years_ia, y=y_withdrawals_ia, mode='lines+markers', name=gettext("Annual Withdrawal (What-If)"), line=dict(color='green'))) # Changed
                 else:
-                    fig_withdrawals.add_trace(go.Scatter(x=[], y=[], mode='lines+markers', name="Annual Withdrawal (What-If)", line=dict(color='green')))
+                    fig_withdrawals.add_trace(go.Scatter(x=[], y=[], mode='lines+markers', name=gettext("Annual Withdrawal (What-If)"), line=dict(color='green'))) # Changed
                     if total_T_sim_ia > 0:
                          current_app.logger.warning(f"Interactive withdrawal plot data length mismatch: x_data (len {len(x_withdraw_years_ia)}), y_data (len {total_T_sim_ia})")
-                fig_withdrawals.update_layout(title="Annual Withdrawals Over Time (What-If)", xaxis_title="Year", yaxis_title="Annual Withdrawal Amount", autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2))
-                plot2_spec_interactive = {'data': [trace.to_plotly_json() for trace in fig_balance.data], 'layout': fig_withdrawals.layout.to_plotly_json()} # Corrected: fig_withdrawals.data
+                fig_withdrawals.update_layout(title=gettext("Annual Withdrawals Over Time (What-If)"), xaxis_title=gettext("Year"), yaxis_title=gettext("Annual Withdrawal Amount"), autosize=True, margin=dict(l=30, r=20, t=40, b=40, pad=2)) # Changed
+                plot2_spec_interactive = {'data': [trace.to_plotly_json() for trace in fig_withdrawals.data], 'layout': fig_withdrawals.layout.to_plotly_json()} # Corrected: fig_withdrawals.data
             except Exception as e_plot2_ia:
                 current_app.logger.error(f"Error generating interactive withdrawal plot spec: {e_plot2_ia}", exc_info=True)
 
@@ -407,55 +404,50 @@ def wizard_recalculate_interactive():
         })
     except Exception as e:
         current_app.logger.error(f"Error in /recalculate_interactive: {e}", exc_info=True)
-        return jsonify({'error': 'An unexpected server error occurred.'}), 500
-
-import csv
-import io
-from flask import Response
+        return jsonify({'error': gettext('An unexpected server error occurred.')}), 500 # Changed
 
 @wizard_bp.route('/export/csv')
 def export_csv():
     export_data = session.get('last_calc_export_data')
     if not export_data:
-        flash("No calculation data available to export. Please perform a calculation first.", "error")
+        flash(gettext("No calculation data available to export. Please perform a calculation first."), "error") # Changed
         return redirect(url_for('wizard_bp.wizard_summary_step'))
 
     output = io.StringIO()
     writer = csv.writer(output)
-    # Use gettext for CSV headers
-    writer.writerow([current_app.extensions['babel'].gettext("FIRE Calculation Summary")])
+    writer.writerow([gettext("FIRE Calculation Summary")])
     writer.writerow([])
-    writer.writerow([current_app.extensions['babel'].gettext("Input Annual Expenses (W)"), export_data.get('W')])
-    writer.writerow([current_app.extensions['babel'].gettext("Calculated FIRE Number (P)"), export_data.get('P_calculated')])
-    writer.writerow([current_app.extensions['babel'].gettext("Overall Nominal Return Rate (%)"), export_data.get('r_overall_nominal') * 100 if export_data.get('r_overall_nominal') is not None else 'N/A'])
-    writer.writerow([current_app.extensions['babel'].gettext("Overall Inflation Rate (%)"), export_data.get('i_overall') * 100 if export_data.get('i_overall') is not None else 'N/A'])
-    writer.writerow([current_app.extensions['babel'].gettext("Total Duration (years)"), export_data.get('total_duration_from_periods')])
-    writer.writerow([current_app.extensions['babel'].gettext("Withdrawal Timing"), str(export_data.get('withdrawal_time_str', '')).capitalize()])
-    writer.writerow([current_app.extensions['babel'].gettext("Desired Final Portfolio Value"), export_data.get('desired_final_value')])
+    writer.writerow([gettext("Input Annual Expenses (W)"), export_data.get('W')])
+    writer.writerow([gettext("Calculated FIRE Number (P)"), export_data.get('P_calculated')])
+    writer.writerow([gettext("Overall Nominal Return Rate (%)"), export_data.get('r_overall_nominal') * 100 if export_data.get('r_overall_nominal') is not None else 'N/A'])
+    writer.writerow([gettext("Overall Inflation Rate (%)"), export_data.get('i_overall') * 100 if export_data.get('i_overall') is not None else 'N/A'])
+    writer.writerow([gettext("Total Duration (years)"), export_data.get('total_duration_from_periods')])
+    writer.writerow([gettext("Withdrawal Timing"), str(export_data.get('withdrawal_time_str', '')).capitalize()])
+    writer.writerow([gettext("Desired Final Portfolio Value"), export_data.get('desired_final_value')])
 
     writer.writerow([])
-    writer.writerow([current_app.extensions['babel'].gettext("Rate Periods Applied:")])
+    writer.writerow([gettext("Rate Periods Applied:")])
     rates_p = export_data.get('rates_periods_summary', [])
     if rates_p:
-        writer.writerow([current_app.extensions['babel'].gettext("Period Duration (Yrs)"), current_app.extensions['babel'].gettext("Nominal Return Rate (%)"), current_app.extensions['babel'].gettext("Inflation Rate (%) Used")])
+        writer.writerow([gettext("Period Duration (Yrs)"), gettext("Nominal Return Rate (%)"), gettext("Inflation Rate (%) Used")])
         for p in rates_p:
             writer.writerow([p.get('duration'), p.get('r') * 100 if p.get('r') is not None else 'N/A', p.get('i') * 100 if p.get('i') is not None else 'N/A'])
     else:
-        writer.writerow([current_app.extensions['babel'].gettext("N/A (Used overall rates for total duration)")])
+        writer.writerow([gettext("N/A (Used overall rates for total duration)")])
 
     writer.writerow([])
-    writer.writerow([current_app.extensions['babel'].gettext("One-Off Events Considered:")])
+    writer.writerow([gettext("One-Off Events Considered:")])
     one_offs = export_data.get('one_off_events_summary', [])
     if one_offs:
-        writer.writerow([current_app.extensions['babel'].gettext("Year"), current_app.extensions['babel'].gettext("Amount")])
+        writer.writerow([gettext("Year"), gettext("Amount")])
         for event in one_offs:
             writer.writerow([event.get('year'), event.get('amount')])
     else:
-        writer.writerow([current_app.extensions['babel'].gettext("None")])
+        writer.writerow([gettext("None")])
 
     writer.writerow([])
-    writer.writerow([current_app.extensions['babel'].gettext("Year-by-Year Simulation")])
-    writer.writerow([current_app.extensions['babel'].gettext("Year"), current_app.extensions['babel'].gettext("Portfolio Balance (End of Year)"), current_app.extensions['babel'].gettext("Annual Withdrawal")])
+    writer.writerow([gettext("Year-by-Year Simulation")])
+    writer.writerow([gettext("Year"), gettext("Portfolio Balance (End of Year)"), gettext("Annual Withdrawal")])
 
     sim_years_exp = export_data.get('sim_years', [])
     sim_balances_exp = export_data.get('sim_balances', [])
@@ -469,9 +461,9 @@ def export_csv():
             withdrawal = sim_withdrawals_exp[i]
             writer.writerow([int(year_display), f"{balance:.2f}", f"{withdrawal:.2f}"])
     elif not sim_years_exp and not sim_balances_exp and not sim_withdrawals_exp :
-          writer.writerow([current_app.extensions['babel'].gettext("N/A - No simulation years to display (e.g., T=0 or calculation issue).")])
+          writer.writerow([gettext("N/A - No simulation years to display (e.g., T=0 or calculation issue).")]) # Changed
     else:
-          writer.writerow([current_app.extensions['babel'].gettext("N/A - Simulation data inconsistent or unavailable for table.")])
+          writer.writerow([gettext("N/A - Simulation data inconsistent or unavailable for table.")]) # Changed
 
     output.seek(0)
     return Response(
@@ -484,28 +476,28 @@ def export_csv():
 def export_pdf():
     export_data = session.get('last_calc_export_data')
     if not export_data:
-        flash(current_app.extensions['babel'].gettext("No calculation data available to export. Please perform a calculation first."), "error")
+        flash(gettext("No calculation data available to export. Please perform a calculation first."), "error") # Changed
         return redirect(url_for('wizard_bp.wizard_summary_step'))
 
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font("Arial", "B", 16)
 
-    pdf.cell(0, 10, current_app.extensions['babel'].gettext("FIRE Calculation Results"), 0, 1, "C")
+    pdf.cell(0, 10, gettext("FIRE Calculation Results"), 0, 1, "C") # Changed
     pdf.ln(5)
 
     pdf.set_font("Arial", "B", 12)
-    pdf.cell(0, 10, current_app.extensions['babel'].gettext("Summary of Inputs & Key Results:"), 0, 1)
+    pdf.cell(0, 10, gettext("Summary of Inputs & Key Results:"), 0, 1) # Changed
     pdf.set_font("Arial", "", 10)
 
     input_summary = [
-        (current_app.extensions['babel'].gettext("Input Annual Expenses (W)"), export_data.get('W')),
-        (current_app.extensions['babel'].gettext("Calculated FIRE Number (P)"), export_data.get('P_calculated')),
-        (current_app.extensions['babel'].gettext("Overall Nominal Return Rate (%)"), f"{export_data.get('r_overall_nominal', 0) * 100:.2f}%"),
-        (current_app.extensions['babel'].gettext("Overall Inflation Rate (%)"), f"{export_data.get('i_overall', 0) * 100:.2f}%"),
-        (current_app.extensions['babel'].gettext("Total Duration (years)"), export_data.get('total_duration_from_periods')),
-        (current_app.extensions['babel'].gettext("Withdrawal Timing"), str(export_data.get('withdrawal_time_str', '')).capitalize()),
-        (current_app.extensions['babel'].gettext("Desired Final Portfolio Value"), export_data.get('desired_final_value')),
+        (gettext("Input Annual Expenses (W)"), export_data.get('W')),
+        (gettext("Calculated FIRE Number (P)"), export_data.get('P_calculated')),
+        (gettext("Overall Nominal Return Rate (%)"), f"{export_data.get('r_overall_nominal', 0) * 100:.2f}%"),
+        (gettext("Overall Inflation Rate (%)"), f"{export_data.get('i_overall', 0) * 100:.2f}%"),
+        (gettext("Total Duration (years)"), export_data.get('total_duration_from_periods')),
+        (gettext("Withdrawal Timing"), str(export_data.get('withdrawal_time_str', '')).capitalize()),
+        (gettext("Desired Final Portfolio Value"), export_data.get('desired_final_value')),
     ]
     for key, val in input_summary:
         pdf.cell(90, 7, str(key), 0, 0)
@@ -513,41 +505,41 @@ def export_pdf():
     pdf.ln(3)
 
     pdf.set_font("Arial", "B", 12)
-    pdf.cell(0, 10, current_app.extensions['babel'].gettext("Rate Periods Applied:"), 0, 1)
+    pdf.cell(0, 10, gettext("Rate Periods Applied:"), 0, 1) # Changed
     pdf.set_font("Arial", "", 10)
     rates_p = export_data.get('rates_periods_summary', [])
     if rates_p:
         pdf.set_font("Arial", "B", 10)
-        pdf.cell(40, 7, current_app.extensions['babel'].gettext("Duration (Yrs)"), 1, 0, "C")
-        pdf.cell(60, 7, current_app.extensions['babel'].gettext("Nominal Return (%)"), 1, 0, "C")
-        pdf.cell(60, 7, current_app.extensions['babel'].gettext("Inflation Used (%)"), 1, 1, "C")
+        pdf.cell(40, 7, gettext("Duration (Yrs)"), 1, 0, "C") # Changed
+        pdf.cell(60, 7, gettext("Nominal Return (%)"), 1, 0, "C") # Changed
+        pdf.cell(60, 7, gettext("Inflation Used (%)"), 1, 1, "C") # Changed
         pdf.set_font("Arial", "", 10)
-        for p_item in rates_p: # Renamed p to p_item
+        for p_item in rates_p:
             pdf.cell(40, 7, str(p_item.get('duration')), 1, 0, "C")
             pdf.cell(60, 7, f"{p_item.get('r',0)*100:.2f}", 1, 0, "C")
             pdf.cell(60, 7, f"{p_item.get('i',0)*100:.2f}", 1, 1, "C")
     else:
-        pdf.cell(0, 7, current_app.extensions['babel'].gettext("N/A (Used overall rates for total duration)"), 0, 1)
+        pdf.cell(0, 7, gettext("N/A (Used overall rates for total duration)"), 0, 1) # Changed
     pdf.ln(3)
 
     pdf.set_font("Arial", "B", 12)
-    pdf.cell(0, 10, current_app.extensions['babel'].gettext("One-Off Events Considered:"), 0, 1)
+    pdf.cell(0, 10, gettext("One-Off Events Considered:"), 0, 1) # Changed
     pdf.set_font("Arial", "", 10)
     one_offs = export_data.get('one_off_events_summary', [])
     if one_offs:
         pdf.set_font("Arial", "B", 10)
-        pdf.cell(40, 7, current_app.extensions['babel'].gettext("Year"), 1, 0, "C")
-        pdf.cell(60, 7, current_app.extensions['babel'].gettext("Amount"), 1, 1, "C")
+        pdf.cell(40, 7, gettext("Year"), 1, 0, "C") # Changed
+        pdf.cell(60, 7, gettext("Amount"), 1, 1, "C") # Changed
         pdf.set_font("Arial", "", 10)
-        for event_item in one_offs: # Renamed event to event_item
+        for event_item in one_offs:
             pdf.cell(40, 7, str(event_item.get('year')), 1, 0, "C")
             pdf.cell(60, 7, f"{event_item.get('amount', 0):.2f}", 1, 1, "C")
     else:
-        pdf.cell(0, 7, current_app.extensions['babel'].gettext("None"), 0, 1)
+        pdf.cell(0, 7, gettext("None"), 0, 1) # Changed
     pdf.ln(5)
 
     pdf.set_font("Arial", "B", 12)
-    pdf.cell(0, 10, current_app.extensions['babel'].gettext("Charts:"), 0, 1)
+    pdf.cell(0, 10, gettext("Charts:"), 0, 1) # Changed
     pdf.set_font("Arial", "", 10)
 
     plot_temp_files = []
@@ -558,14 +550,14 @@ def export_pdf():
         one_off_events_for_plot = export_data.get('one_off_events_summary', [])
 
         if sim_years_list and sim_balances_list:
-            fig_balance_pdf = go.Figure() # Renamed fig_balance to fig_balance_pdf
-            fig_balance_pdf.add_trace(go.Scatter(x=sim_years_list, y=sim_balances_list, mode='lines+markers', name=current_app.extensions['babel'].gettext('Portfolio Balance')))
-            for event_pdf in one_off_events_for_plot: # Renamed event to event_pdf
+            fig_balance_pdf = go.Figure()
+            fig_balance_pdf.add_trace(go.Scatter(x=sim_years_list, y=sim_balances_list, mode='lines+markers', name=gettext('Portfolio Balance'))) # Changed
+            for event_pdf in one_off_events_for_plot:
                 if 0 <= event_pdf['year'] < len(sim_balances_list):
                     event_y_approx = sim_balances_list[event_pdf['year']]
                     fig_balance_pdf.add_trace(go.Scatter(x=[event_pdf['year']], y=[float(event_y_approx)], mode='markers',
-                                                         marker=dict(size=8, color='red' if event_pdf['amount'] < 0 else 'green'), name=f"Event: {event_pdf['amount']:.0f}"))
-            fig_balance_pdf.update_layout(title=current_app.extensions['babel'].gettext('Portfolio Balance Over Time'), autosize=False, width=500, height=350, margin=dict(l=30,r=20,t=40,b=30))
+                                                         marker=dict(size=8, color='red' if event_pdf['amount'] < 0 else 'green'), name=f"{gettext('Event')}: {event_pdf['amount']:.0f}")) # Changed
+            fig_balance_pdf.update_layout(title=gettext('Portfolio Balance Over Time'), autosize=False, width=500, height=350, margin=dict(l=30,r=20,t=40,b=30)) # Changed
 
             with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp_file_bal:
                 try:
@@ -574,16 +566,16 @@ def export_pdf():
                     plot_temp_files.append(tmp_file_bal.name)
                 except Exception as e_img_bal:
                     current_app.logger.error(f"Failed to write balance plot image: {e_img_bal}")
-                    pdf.cell(0, 7, current_app.extensions['babel'].gettext("Portfolio balance plot could not be generated."), 0, 1)
+                    pdf.cell(0, 7, gettext("Portfolio balance plot could not be generated."), 0, 1) # Changed
             pdf.ln(3)
 
         if sim_years_list and sim_withdrawals_list:
-            total_T_sim_pdf = len(sim_withdrawals_list) # Renamed total_T_sim
-            x_withdraw_years_pdf = sim_years_list[1:total_T_sim_pdf+1] if len(sim_years_list) > total_T_sim_pdf else [] # Renamed x_withdraw_years
+            total_T_sim_pdf = len(sim_withdrawals_list)
+            x_withdraw_years_pdf = sim_years_list[1:total_T_sim_pdf+1] if len(sim_years_list) > total_T_sim_pdf else []
             if len(x_withdraw_years_pdf) == total_T_sim_pdf and total_T_sim_pdf > 0:
-                fig_withdrawals_pdf = go.Figure() # Renamed fig_withdrawals
-                fig_withdrawals_pdf.add_trace(go.Scatter(x=x_withdraw_years_pdf, y=sim_withdrawals_list, mode='lines+markers', name=current_app.extensions['babel'].gettext('Annual Withdrawal')))
-                fig_withdrawals_pdf.update_layout(title=current_app.extensions['babel'].gettext('Annual Withdrawals Over Time'), autosize=False, width=500, height=350, margin=dict(l=30,r=20,t=40,b=30))
+                fig_withdrawals_pdf = go.Figure()
+                fig_withdrawals_pdf.add_trace(go.Scatter(x=x_withdraw_years_pdf, y=sim_withdrawals_list, mode='lines+markers', name=gettext('Annual Withdrawal'))) # Changed
+                fig_withdrawals_pdf.update_layout(title=gettext('Annual Withdrawals Over Time'), autosize=False, width=500, height=350, margin=dict(l=30,r=20,t=40,b=30)) # Changed
                 with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp_file_wd:
                     try:
                         fig_withdrawals_pdf.write_image(tmp_file_wd.name, format='png', scale=2)
@@ -591,12 +583,12 @@ def export_pdf():
                         plot_temp_files.append(tmp_file_wd.name)
                     except Exception as e_img_wd:
                         current_app.logger.error(f"Failed to write withdrawal plot image: {e_img_wd}")
-                        pdf.cell(0, 7, current_app.extensions['babel'].gettext("Annual withdrawal plot could not be generated."), 0, 1)
+                        pdf.cell(0, 7, gettext("Annual withdrawal plot could not be generated."), 0, 1) # Changed
             elif total_T_sim_pdf == 0:
-                 pdf.cell(0, 7, current_app.extensions['babel'].gettext("No withdrawal data to plot (e.g. T=0)."), 0, 1)
+                 pdf.cell(0, 7, gettext("No withdrawal data to plot (e.g. T=0)."), 0, 1) # Changed
     except Exception as e_plots:
         current_app.logger.error(f"Error during plot generation for PDF: {e_plots}")
-        pdf.cell(0, 7, current_app.extensions['babel'].gettext("Plots could not be generated due to an error."), 0, 1)
+        pdf.cell(0, 7, gettext("Plots could not be generated due to an error."), 0, 1) # Changed
     finally:
         for temp_file_path in plot_temp_files:
             try:
@@ -606,14 +598,14 @@ def export_pdf():
     pdf.ln(5)
 
     pdf.set_font("Arial", "B", 12)
-    pdf.cell(0, 10, current_app.extensions['babel'].gettext("Year-by-Year Simulation:"), 0, 1)
+    pdf.cell(0, 10, gettext("Year-by-Year Simulation:"), 0, 1) # Changed
     pdf.set_font("Arial", "B", 10)
-    pdf.cell(40, 7, current_app.extensions['babel'].gettext("Year"), 1, 0, "C")
-    pdf.cell(75, 7, current_app.extensions['babel'].gettext("Portfolio Balance (End)"), 1, 0, "C")
-    pdf.cell(75, 7, current_app.extensions['babel'].gettext("Annual Withdrawal"), 1, 1, "C")
+    pdf.cell(40, 7, gettext("Year"), 1, 0, "C") # Changed
+    pdf.cell(75, 7, gettext("Portfolio Balance (End)"), 1, 0, "C") # Changed
+    pdf.cell(75, 7, gettext("Annual Withdrawal"), 1, 1, "C") # Changed
     pdf.set_font("Arial", "", 10)
 
-    sim_years_pdf_table = export_data.get('sim_years', []) # Renamed for clarity
+    sim_years_pdf_table = export_data.get('sim_years', [])
     sim_balances_pdf_table = export_data.get('sim_balances', [])
     sim_withdrawals_pdf_table = export_data.get('sim_withdrawals', [])
     total_T_sim_pdf_table = len(sim_withdrawals_pdf_table)
@@ -624,7 +616,7 @@ def export_pdf():
             pdf.cell(75, 7, f"{sim_balances_pdf_table[i+1]:.2f}", 1, 0, "R")
             pdf.cell(75, 7, f"{sim_withdrawals_pdf_table[i]:.2f}", 1, 1, "R")
     else:
-        pdf.cell(0, 7, current_app.extensions['babel'].gettext("N/A - No simulation years to display or data inconsistent."), 1, 1, "C")
+        pdf.cell(0, 7, gettext("N/A - No simulation years to display or data inconsistent."), 1, 1, "C") # Changed
 
     return Response(
         pdf.output(dest='S').encode('latin-1'),


### PR DESCRIPTION
Resolves an `AttributeError: 'BabelConfiguration' object has no attribute 'gettext'` that occurred in `project/wizard_routes.py` within functions like `export_csv`, `export_pdf`, and potentially others.

The error was caused by attempting to call gettext via `current_app.extensions['babel'].gettext("...")` or using an undefined `_("...")` alias within the Python file's scope.

Changes:
- I added `from flask_babel import gettext` at the top of `project/wizard_routes.py`.
- I replaced all instances of `current_app.extensions['babel'].gettext("...")` and any direct `_("...")` calls (where `_` was not a defined alias for `gettext` in that context) with `gettext("...")`. This applies to translatable strings used in flash messages, error messages, plot titles/labels, and content generated for CSV/PDF exports within the route functions.

This ensures that server-side translations in the Python code use the standard `flask_babel.gettext` function correctly.