### PR TITLE
fix: Correct PDF export dependencies and encoding error

### DIFF
--- a/project/wizard_routes.py
+++ b/project/wizard_routes.py
@@ -619,7 +619,7 @@ def export_pdf():
         pdf.cell(0, 7, gettext("N/A - No simulation years to display or data inconsistent."), 1, 1, "C") # Changed
 
     return Response(
-        pdf.output(dest='S').encode('latin-1'),
+        pdf.output(dest='S'), # FPDF.output(dest='S') returns bytes
         mimetype='application/pdf',
         headers={'Content-Disposition': 'attachment;filename=fire_calculation_results.pdf'}
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gunicorn
 Flask-Babel
 Flask-WTF
 fpdf2
+kaleido


### PR DESCRIPTION
This commit addresses two issues related to PDF export functionality:

1.  **Add `kaleido` to `requirements.txt`:**
    - The `kaleido` package is required by Plotly's `write_image()` method for exporting figures to static image formats (like PNGs) which are then embedded in the PDF.
    - Added `kaleido` to `requirements.txt` to ensure this dependency is declared and can be installed in the environment.
    - This resolves errors logged as "Image export using the 'kaleido' engine requires the kaleido package".

2.  **Fix `AttributeError` in `export_pdf` Function:**
    - In `project/wizard_routes.py`, within the `export_pdf` function, the line `pdf.output(dest='S').encode('latin-1')` was changed to just `pdf.output(dest='S')`.
    - The `FPDF.output(dest='S')` method returns a `bytes` object (or `bytearray`), which is already the correct format for the Flask `Response`. Attempting to `.encode()` this byte-like object caused an `AttributeError: 'bytearray' object has no attribute 'encode'`.
    - Removing the `.encode()` call resolves this error.

These changes ensure that the necessary dependency for plot image generation is specified and that the PDF content is correctly handled for the Flask response, improving the reliability of the PDF export feature.