### PR TITLE
feat: Initial UI Revamp based on Reference Templates (Phase 1)

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,41 +1,98 @@
-/* static/css/main.css */
 :root {
-  --bg-light: #fefefe;
-  --bg-accent: #A8E6CF;
-  --bg-secondary: #FFD3B6;
-  --text-light: #333;
-  --panel-rgb: 255, 255, 255; /* Light theme panel RGB */
-  --panel-alpha: 0.7;       /* Default panel alpha */
-  --panel-bg: rgba(var(--panel-rgb), var(--panel-alpha));
-  --input-range-bg: rgba(255,255,255,0.4);
-  --thumb-bg: #fff;
-  --thumb-border: #A8E6CF;
-  --font-size: 16px; /* Default font size */
+    --transition-speed: 0.4s;
 }
 
-[data-bs-theme="dark"] {
-  --bg-light: #1E1E1E;
-  /* Dark theme gradient colors */
-  --bg-accent: #2E3C40; /* Dark Slate / Deep Teal */
-  --bg-secondary: #1A2930; /* Very Dark Blue / Almost Black Blue */
-  --text-light: #e0e0e0;
-  --panel-rgb: 30, 30, 30;   /* Dark theme panel RGB */
-  --panel-alpha: 0.9;       /* Default dark theme panel alpha */
-  --panel-bg: rgba(var(--panel-rgb), var(--panel-alpha));
-  --input-range-bg: rgba(255,255,255,0.2);
-  --thumb-bg: #e0e0e0;
-  --thumb-border: #80CBC4;
+/* --- Theme & Mode Definitions --- */
+[data-theme='default'][data-mode='light'] { --bg-primary-rgb: 248, 249, 250; --bg-secondary-rgb: 255, 255, 255; --text-primary: #212529; --text-secondary: #6c757d; --border-color: #ced4da; --shadow-color: rgb(0 0 0 / 0.1); --hero-gradient: linear-gradient(120deg, #a1c4fd 0%, #c2e9fb 100%); --accent-color: #007bff; --accent-hover: #0056b3; --accent-text: #ffffff; }
+[data-theme='default'][data-mode='dark'] { --bg-primary-rgb: 18, 18, 18; --bg-secondary-rgb: 30, 30, 30; --text-primary: #e9ecef; --text-secondary: #adb5bd; --border-color: #495057; --shadow-color: rgb(0 0 0 / 0.4); --hero-gradient: linear-gradient(120deg, #023e8a 0%, #0077b6 100%); --accent-color: #0d6efd; --accent-hover: #3b82f6; --accent-text: #ffffff; }
+[data-theme='oceanic'][data-mode='light'] { --bg-primary-rgb: 240, 247, 255; --bg-secondary-rgb: 255, 255, 255; --text-primary: #0a3d62; --text-secondary: #3c6382; --border-color: #a7c5eb; --shadow-color: rgb(60 99 130 / 0.15); --hero-gradient: linear-gradient(120deg, #89f7fe 0%, #66a6ff 100%); --accent-color: #0c7b93; --accent-hover: #1491a9; --accent-text: #ffffff; }
+[data-theme='oceanic'][data-mode='dark'] { --bg-primary-rgb: 15, 23, 42; --bg-secondary-rgb: 30, 41, 59; --text-primary: #e0f2fe; --text-secondary: #94a3b8; --border-color: #334155; --shadow-color: rgb(15 23 42 / 0.5); --hero-gradient: linear-gradient(120deg, #1d2b64 0%, #f8cdda 100%); --accent-color: #22d3ee; --accent-hover: #67e8f9; --accent-text: #111827; }
+[data-theme='forest'][data-mode='light'] { --bg-primary-rgb: 244, 246, 240; --bg-secondary-rgb: 255, 255, 255; --text-primary: #2d382c; --text-secondary: #515e4f; --border-color: #c8d3c5; --shadow-color: rgb(45 56 44 / 0.1); --hero-gradient: linear-gradient(120deg, #d4fc79 0%, #96e6a1 100%); --accent-color: #4a7c59; --accent-hover: #5a936a; --accent-text: #ffffff; }
+[data-theme='forest'][data-mode='dark'] { --bg-primary-rgb: 26, 32, 26; --bg-secondary-rgb: 41, 50, 42; --text-primary: #f0f6f0; --text-secondary: #a8b8a8; --border-color: #404a40; --shadow-color: rgb(26 32 26 / 0.5); --hero-gradient: linear-gradient(120deg, #087f5b 0%, #173d32 100%); --accent-color: #4ade80; --accent-hover: #86efac; --accent-text: #1a201a; }
+[data-theme='sunrise'][data-mode='light'] { --bg-primary-rgb: 255, 248, 240; --bg-secondary-rgb: 255, 255, 255; --text-primary: #5c3d1e; --text-secondary: #8c6d46; --border-color: #f7d9aa; --shadow-color: rgb(247 217 170 / 0.2); --hero-gradient: linear-gradient(120deg, #f6d365 0%, #fda085 100%); --accent-color: #ff8c42; --accent-hover: #ffa263; --accent-text: #ffffff; }
+[data-theme='sunrise'][data-mode='dark'] { --bg-primary-rgb: 40, 28, 13; --bg-secondary-rgb: 66, 45, 22; --text-primary: #fffbeb; --text-secondary: #d7c6b0; --border-color: #5c3d1e; --shadow-color: rgb(40 28 13 / 0.5); --hero-gradient: linear-gradient(120deg, #b22a00 0%, #ff8c42 100%); --accent-color: #fb923c; --accent-hover: #fdba74; --accent-text: #422d16; }
+[data-theme='maroon'][data-mode='light'] { --bg-primary-rgb: 253, 242, 242; --bg-secondary-rgb: 255, 255, 255; --text-primary: #5c0000; --text-secondary: #804040; --border-color: #e6c0c0; --shadow-color: rgb(92 0 0 / 0.1); --hero-gradient: linear-gradient(120deg, #f093fb 0%, #f5576c 100%); --accent-color: #800000; --accent-hover: #a00000; --accent-text: #ffffff; }
+[data-theme='maroon'][data-mode='dark'] { --bg-primary-rgb: 26, 18, 18; --bg-secondary-rgb: 42, 32, 32; --text-primary: #fde8e8; --text-secondary: #c9b8b8; --border-color: #5c2020; --shadow-color: rgb(26 18 18 / 0.5); --hero-gradient: linear-gradient(120deg, #870000 0%, #190a05 100%); --accent-color: #c04040; --accent-hover: #e06060; --accent-text: #fde8e8; }
+[data-theme='amethyst'][data-mode='light'] { --bg-primary-rgb: 250, 245, 255; --bg-secondary-rgb: 255, 255, 255; --text-primary: #4c1d95; --text-secondary: #6d28d9; --border-color: #d8b4fe; --shadow-color: rgb(76 29 149 / 0.1); --hero-gradient: linear-gradient(120deg, #d299c2 0%, #fef9d7 100%); --accent-color: #8b5cf6; --accent-hover: #a78bfa; --accent-text: #ffffff; }
+[data-theme='amethyst'][data-mode='dark'] { --bg-primary-rgb: 24, 18, 43; --bg-secondary-rgb: 41, 32, 62; --text-primary: #f5d0fe; --text-secondary: #e9d5ff; --border-color: #581c87; --shadow-color: rgb(24 18 43 / 0.5); --hero-gradient: linear-gradient(120deg, #371060 0%, #c026d3 100%); --accent-color: #c084fc; --accent-hover: #d8b4fe; --accent-text: #27123A; }
+[data-theme='emerald'][data-mode='light'] { --bg-primary-rgb: 240, 253, 244; --bg-secondary-rgb: 255, 255, 255; --text-primary: #047857; --text-secondary: #059669; --border-color: #a7f3d0; --shadow-color: rgb(4 120 87 / 0.1); --hero-gradient: linear-gradient(120deg, #5ee7df 0%, #b490ca 100%); --accent-color: #10b981; --accent-hover: #34d399; --accent-text: #ffffff; }
+[data-theme='emerald'][data-mode='dark'] { --bg-primary-rgb: 12, 35, 23; --bg-secondary-rgb: 19, 58, 41; --text-primary: #d1fae5; --text-secondary: #a7f3d0; --border-color: #065f46; --shadow-color: rgb(12 35 23 / 0.5); --hero-gradient: linear-gradient(120deg, #004643 0%, #0c7489 100%); --accent-color: #34d399; --accent-hover: #6ee7b7; --accent-text: #064E3B; }
+[data-theme='slate'][data-mode='light'] { --bg-primary-rgb: 241, 245, 249; --bg-secondary-rgb: 255, 255, 255; --text-primary: #334155; --text-secondary: #64748b; --border-color: #cbd5e1; --shadow-color: rgb(51 65 85 / 0.1); --hero-gradient: linear-gradient(120deg, #d3cce3 0%, #e9e4f0 100%); --accent-color: #475569; --accent-hover: #64748b; --accent-text: #ffffff; }
+[data-theme='slate'][data-mode='dark'] { --bg-primary-rgb: 15, 23, 42; --bg-secondary-rgb: 30, 41, 59; --text-primary: #f1f5f9; --text-secondary: #94a3b8; --border-color: #475569; --shadow-color: rgb(15 23 42 / 0.5); --hero-gradient: linear-gradient(120deg, #2c3e50 0%, #4ca1af 100%); --accent-color: #94a3b8; --accent-hover: #cbd5e1; --accent-text: #0f172a; }
+[data-theme='tangerine'][data-mode='light'] { --bg-primary-rgb: 255, 247, 237; --bg-secondary-rgb: 255, 255, 255; --text-primary: #c2410c; --text-secondary: #ea580c; --border-color: #fed7aa; --shadow-color: rgb(194 65 12 / 0.1); --hero-gradient: linear-gradient(120deg, #f83600 0%, #f9d423 100%); --accent-color: #f97316; --accent-hover: #fb923c; --accent-text: #ffffff; }
+[data-theme='tangerine'][data-mode='dark'] { --bg-primary-rgb: 36, 19, 3; --bg-secondary-rgb: 60, 31, 6; --text-primary: #ffedd5; --text-secondary: #fed7aa; --border-color: #9a3412; --shadow-color: rgb(36 19 3 / 0.5); --hero-gradient: linear-gradient(120deg, #dd2476 0%, #ff512f 100%); --accent-color: #fb923c; --accent-hover: #fdba74; --accent-text: #78350F; }
+[data-theme='rose'][data-mode='light'] { --bg-primary-rgb: 255, 241, 242; --bg-secondary-rgb: 255, 255, 255; --text-primary: #be123c; --text-secondary: #e11d48; --border-color: #fecdd3; --shadow-color: rgb(190 18 60 / 0.1); --hero-gradient: linear-gradient(120deg, #fbc2eb 0%, #a6c1ee 100%); --accent-color: #f43f5e; --accent-hover: #fb7185; --accent-text: #ffffff; }
+[data-theme='rose'][data-mode='dark'] { --bg-primary-rgb: 39, 13, 19; --bg-secondary-rgb: 64, 21, 31; --text-primary: #fff1f2; --text-secondary: #fecdd3; --border-color: #be123c; --shadow-color: rgb(39 13 19 / 0.5); --hero-gradient: linear-gradient(120deg, #ff0844 0%, #ffb199 100%); --accent-color: #fb7185; --accent-hover: #fca5a5; --accent-text: #881337; }
+
+/* --- Component Styling with Glassmorphism --- */
+.glassmorphic {
+    background-color: rgba(var(--bg-secondary-rgb), 0.65);
+    backdrop-filter: blur(12px) saturate(150%);
+    -webkit-backdrop-filter: blur(12px) saturate(150%);
+    border: 1px solid rgba(var(--border-color), 0.3);
+    box-shadow: 0 8px 32px 0 var(--shadow-color);
+    transition: background-color var(--transition-speed) ease, border-color var(--transition-speed) ease;
 }
+
+/* --- Utility Styles --- */
+.nav {
+    transition: background-color var(--transition-speed) ease;
+    border-bottom: 1px solid rgba(var(--border-color), 0.2);
+}
+.btn-primary {
+    background-color: var(--accent-color);
+    color: var(--accent-text);
+    transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease;
+}
+.btn-primary:hover {
+    background-color: var(--accent-hover);
+}
+.text-primary {
+    color: var(--text-primary);
+}
+.text-secondary {
+    color: var(--text-secondary);
+}
+.settings-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.3);
+    backdrop-filter: blur(5px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+.settings-modal.is-open {
+    opacity: 1;
+    visibility: visible;
+}
+.mode-toggle-bg {
+    background-color: color-mix(in srgb, var(--border-color) 50%, transparent);
+}
+.mode-toggle-bg.dark {
+    background-color: var(--accent-color);
+}
+
+/* --- End of extracted styles --- */
+/* static/css/main.css */
 
 body {
-  /* font-family: 'Roboto', sans-serif; */ /* Handled by Bootstrap, but Roboto is a good choice if we customize BS's font stack */
+  font-family: 'Inter', sans-serif; /* Added */
   /* font-size: var(--font-size); */ /* Base font size set by Bootstrap, can be overridden via --bs-body-font-size */
   /* margin: 0; */ /* Handled by Bootstrap */
   /* padding: 0; */ /* Handled by Bootstrap */
-  background: linear-gradient(135deg, var(--bg-accent) 0%, var(--bg-secondary) 100%);
-  color: var(--text-light); /* This will be overridden by Bootstrap's default body color or more specific selectors */
+  background-image: var(--hero-gradient); /* Changed */
+  background-attachment: fixed; /* Added */
+  color: var(--text-primary); /* Changed */
   /* overflow-x: hidden; */ /* Generally good, Bootstrap might handle this via .container or specific utilities */
-  transition: background 0.5s, color 0.5s;
+  transition: background-image var(--transition-speed) ease, color var(--transition-speed) ease, background-color var(--transition-speed) ease; /* Changed */
 }
 
 /*

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,68 +1,68 @@
-// static/js/theme.js
+document.addEventListener('DOMContentLoaded', () => {
+    const settingsButton = document.getElementById('settings-button');
+    const settingsModal = document.getElementById('settings-modal');
+    const settingsCloseButton = document.getElementById('settings-close-button');
+    const themeSelector = document.getElementById('theme-selector');
+    const modeToggle = document.getElementById('mode-toggle');
+    const modeToggleCircle = document.getElementById('mode-toggle-circle');
+    const root = document.documentElement;
 
-// Store the media query globally to easily add/remove listener
-const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+    const themes = [
+        { name: 'default', label: 'Default' }, { name: 'oceanic', label: 'Oceanic' }, { name: 'forest', label: 'Forest' }, { name: 'sunrise', label: 'Sunrise' }, { name: 'maroon', label: 'Maroon' }, { name: 'amethyst', label: 'Amethyst' }, { name: 'emerald', label: 'Emerald' }, { name: 'slate', label: 'Slate' }, { name: 'tangerine', label: 'Tangerine' }, { name: 'rose', label: 'Rose' }
+    ];
 
-function getActualTheme(storedTheme) {
-  if (storedTheme === 'system') {
-    return prefersDarkScheme.matches ? 'dark' : 'light';
-  }
-  // Default to 'light' if storedTheme is null, undefined, or not 'dark' (e.g. old invalid values)
-  return (storedTheme === 'dark') ? 'dark' : 'light'; 
-}
+    const applySettings = (themeName, modeName) => {
+        root.dataset.theme = themeName;
+        root.dataset.mode = modeName;
+        localStorage.setItem('fire-calc-theme', themeName);
+        localStorage.setItem('fire-calc-mode', modeName);
 
-function applyTheme() {
-  let storedTheme = localStorage.getItem('theme'); // Can be 'light', 'dark', or 'system'
-  if (storedTheme === null) {
-      // If no theme is stored (e.g., first visit), default to 'system'.
-      storedTheme = 'system';
-      // Optionally, save 'system' to localStorage so this becomes the persistent choice
-      // until the user manually changes it via the toggle.
-      localStorage.setItem('theme', 'system');
-  }
-  
-  const actualThemeToApply = getActualTheme(storedTheme);
+        document.querySelectorAll('.theme-button').forEach(btn => {
+            btn.classList.toggle('ring-2', btn.dataset.theme === themeName);
+            btn.classList.toggle('ring-[var(--accent-color)]', btn.dataset.theme === themeName);
+        });
 
-  document.documentElement.setAttribute('data-bs-theme', actualThemeToApply);
-  document.documentElement.style.colorScheme = actualThemeToApply;
+        const isDark = modeName === 'dark';
+        modeToggle.classList.toggle('dark', isDark);
+        modeToggleCircle.classList.toggle('translate-x-5', isDark);
+    };
 
-  // Manage system theme listener
-  if (storedTheme === 'system') {
-    // Add listener only if it's not already there (though modern browsers handle duplicates)
-    prefersDarkScheme.removeEventListener('change', handleSystemThemeChange); // Remove first to avoid duplicates if logic is complex
-    prefersDarkScheme.addEventListener('change', handleSystemThemeChange);
-  } else {
-    prefersDarkScheme.removeEventListener('change', handleSystemThemeChange);
-  }
+    themes.forEach(theme => {
+        const button = document.createElement('button');
+        button.textContent = theme.label;
+        button.dataset.theme = theme.name;
+        button.className = 'theme-button w-full text-left p-3 rounded-lg border border-opacity-50 transition-all';
+        button.addEventListener('click', () => {
+            const currentMode = root.dataset.mode;
+            applySettings(theme.name, currentMode);
+        });
+        themeSelector.appendChild(button);
+    });
 
-  // Apply other visual settings from fireSettings if they exist
-  const fireSettingsSaved = localStorage.getItem("fireSettings");
-  if (fireSettingsSaved) {
-     const settings = JSON.parse(fireSettingsSaved);
-     if (settings.fontSize) {
-         document.documentElement.style.setProperty("--font-size", settings.fontSize + "px");
-         // For Bootstrap 5 body font size, if you transition to this:
-         // document.documentElement.style.setProperty("--bs-body-font-size", (parseInt(settings.fontSize) / 16) + "rem");
-     }
-     if (settings.panelOpacity) {
-         // This assumes your CSS uses --panel-alpha for opacity in panel backgrounds
-         document.documentElement.style.setProperty("--panel-alpha", settings.panelOpacity);
-     }
-  }
-}
+    modeToggle.addEventListener('click', () => {
+        const newMode = root.dataset.mode === 'light' ? 'dark' : 'light';
+        const currentTheme = root.dataset.theme;
+        applySettings(currentTheme, newMode);
+    });
 
-function handleSystemThemeChange() {
-  // This function is called when the system theme changes AND 'system' is the selected theme.
-  applyTheme(); // Re-apply based on the new system preference
-}
+    const savedTheme = localStorage.getItem('fire-calc-theme') || 'default';
+    const savedMode = localStorage.getItem('fire-calc-mode') || 'light';
+    applySettings(savedTheme, savedMode);
 
-function toggleTheme() {
-  // When toggling, explicitly set to light or dark, effectively overriding 'system' preference.
-  let currentAppliedTheme = document.documentElement.getAttribute('data-bs-theme');
-  const newTheme = currentAppliedTheme === 'dark' ? 'light' : 'dark';
-  localStorage.setItem('theme', newTheme); // Save the explicit choice
-  applyTheme(); // This will also remove the system listener if it was active.
-}
-
-// Initial theme application when the script loads
-applyTheme();
+    // Check if settingsButton exists before adding event listener
+    if (settingsButton) {
+        settingsButton.addEventListener('click', () => settingsModal.classList.add('is-open'));
+    }
+    // Check if settingsCloseButton exists
+    if (settingsCloseButton) {
+        settingsCloseButton.addEventListener('click', () => settingsModal.classList.remove('is-open'));
+    }
+    // Check if settingsModal exists
+    if (settingsModal) {
+        settingsModal.addEventListener('click', (event) => {
+            if (event.target === settingsModal) {
+                settingsModal.classList.remove('is-open');
+            }
+        });
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,30 +1,21 @@
 <!doctype html>
-<html lang="en" data-bs-theme="light"> {# Default to light theme for Bootstrap #}
+<html lang="en" data-theme="default" data-mode="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}{{ _("FIRE Calculator") }}{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
   {% block head_extra %}{% endblock %}
 </head>
 <body>
-  <header class="container mt-3 mb-3 text-center">
-    <h1>
-      <span class="title-tooltip-container">
-        <a class="text-decoration-none" href="{{ url_for('project.index') }}">{{ _("FIRE Calculator") }}</a>
-        <span class="tooltip-text main-title-tooltip">{{ _("Financial Independence, Retire Early: A movement dedicated to a program of extreme savings and investment that aims to allow proponents to retire far earlier than traditional budgets and retirement plans would permit.") }}</span>
-      </span>
-    </h1>
-    <div class="sub-nav">
-      <a href="{{ url_for('project.index') }}" class="sub-nav-item {% if request.endpoint == 'project.index' %}active{% endif %}">{{ _("Home") }}</a>
-      <a href="{{ url_for('project.compare') }}" class="sub-nav-item {% if request.endpoint == 'project.compare' %}active{% endif %}">{{ _("Compare") }}</a>
-      <a href="{{ url_for('project.settings') }}" class="sub-nav-item {% if request.endpoint == 'project.settings' %}active{% endif %}">{{ _("Settings") }}</a>
-      <button class="btn btn-sm btn-outline-secondary sub-nav-item" onclick="toggleTheme()">{{ _("Toggle Theme") }}</button>
-    </div>
-  </header>
+  <nav class="nav glassmorphic sticky top-0 z-50">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"><div class="flex justify-between items-center h-16"><div class="flex-shrink-0"><a href="{{ url_for('project.index') }}" class="text-2xl font-bold text-primary"><span style="color: var(--accent-color);">FIRE</span>Calc</a></div><div class="hidden md:flex items-center space-x-4"><a href="{{ url_for('project.index') }}" class="text-secondary hover:text-primary px-3 py-2 rounded-md text-sm font-medium">Calculator</a><a href="{{ url_for('project.compare') }}" class="text-secondary hover:text-primary px-3 py-2 rounded-md text-sm font-medium">Compare</a><a href="{{ url_for('project.faq') }}" class="text-secondary hover:text-primary px-3 py-2 rounded-md text-sm font-medium">FAQ</a><a href="{{ url_for('project.about') }}" class="text-secondary hover:text-primary px-3 py-2 rounded-md text-sm font-medium">About</a><button id="settings-button" class="p-2 rounded-md text-secondary hover:text-primary"><svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg></button></div></div></div>
+  </nav>
 
-  <main class="container mt-4">
+  <main class="py-12 md:py-20">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
         {% for category, message in messages %}
@@ -36,22 +27,19 @@
       {% endif %}
     {% endwith %}
     {% block content %}{% endblock %}
+    </div>
   </main>
 
-  <footer class="container mt-5 py-3 text-center text-muted">
-    <p>&copy; {{ _("FIRE Calculator") }} {% block year %}{{ current_year }}{% endblock %} |
-      <a href="{{ url_for('project.about') }}" class="text-muted">{{ _("About") }}</a> |
-      <a href="{{ url_for('project.faq') }}" class="text-muted">{{ _("FAQ") }}</a>
-    </p>
+  <footer class="mt-20 bg-black bg-opacity-20 text-white p-8">
+      <div class="text-center text-gray-300">
+          <p>&copy; 2024 FIRECalc. All rights reserved.</p>
+      </div>
   </footer>
+
+  <div id="settings-modal" class="settings-modal"><div class="settings-modal-content glassmorphic"><div class="flex justify-between items-center mb-6"><h3 class="text-xl font-bold text-primary">Settings</h3><button id="settings-close-button" class="p-2 text-secondary hover:text-primary">&times;</button></div><div><h4 class="text-lg font-semibold text-primary mb-4">Color Theme</h4><div id="theme-selector" class="grid grid-cols-2 sm:grid-cols-3 gap-4"></div><hr class="my-6" style="border-color: rgba(var(--border-color), 0.3);"><h4 class="text-lg font-semibold text-primary mb-4">Mode</h4><div class="flex items-center justify-between"><span class="text-secondary">Light</span><button id="mode-toggle" class="relative inline-flex items-center h-6 rounded-full w-11 transition-colors mode-toggle-bg"><span id="mode-toggle-circle" class="inline-block w-4 h-4 transform bg-white rounded-full transition-transform translate-x-1"></span></button><span class="text-secondary">Dark</span></div></div></div></div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
-  <script>
-    // Ensure applyTheme is called to initialize theme based on localStorage
-    // This might be slightly adjusted depending on theme.js and Bootstrap theme integration
-    applyTheme();
-  </script>
   <script src="{{ url_for('static', filename='js/validation.js') }}"></script>
   <script src="https://cdn.plot.ly/plotly-2.20.0.min.js" charset="utf-8"></script>
   {% block scripts_extra %}{% endblock %}

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -3,7 +3,6 @@
 {% block title %}{{ _("Compare Scenarios - FIRE Calculator") }}{% endblock %}
 
 {% block head_extra %}
-  <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
   <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
@@ -11,113 +10,116 @@
 {% endblock %}
 
 {% block content %}
-<div class="container compare-page">
-  <h2>{{ _("Enter Comparison Scenarios") }}</h2>
+<header class="text-center mb-12">
+    <h1 class="text-4xl md:text-5xl font-extrabold text-primary tracking-tight">{{ _("Compare Scenarios") }}</h1>
+    <p class="mt-4 max-w-2xl mx-auto text-lg text-secondary">{{ _("Enter parameters for different scenarios to see how they stack up and how different choices impact your journey to financial independence.") }}</p>
+</header>
+
+<div class="glassmorphic rounded-lg p-4 mb-8 text-secondary">
   <div class="scenario-header mb-3"> {# Added mb-3 for spacing #}
     <label for="scenarioCount" class="form-label">{{ _("Number of Scenarios:") }}</label>
-    <select id="scenarioCount" class="form-select" style="width: auto; display: inline-block;">
+    <select id="scenarioCount" class="themed-select bg-transparent border border-gray-500 rounded-md p-1 text-primary" style="width: auto; display: inline-block;">
       <option value="1">1</option>
       <option value="2" selected>2</option>
       <option value="3">3</option>
       <option value="4">4</option>
     </select>
     &nbsp;&nbsp;
-    <button type="button" class="btn btn-secondary btn-sm" onclick="saveScenarios()">{{ _("Save Scenarios") }}</button>
+    <button type="button" class="btn-primary py-1 px-3 rounded-md text-sm font-semibold" onclick="saveScenarios()">{{ _("Save Scenarios") }}</button>
     &nbsp;&nbsp;
-    <select id="loadScenarioSelect" class="form-select" style="width: auto; display: inline-block;" onchange="loadScenario()"></select>
+    <select id="loadScenarioSelect" class="themed-select bg-transparent border border-gray-500 rounded-md p-1 text-primary" style="width: auto; display: inline-block;" onchange="loadScenario()"></select>
   </div>
+</div>
 
-  <form method="post" action="{{ url_for('project.compare') }}" id="compareForm" class="needs-validation" novalidate>
-    <div class="scenario-container">
+  <form method="post" action="{{ url_for('project.compare') }}" id="compareForm" class="space-y-8">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8 scenario-container">
       {# The scenarios variable is passed from the route #}
       {% for scenario in scenarios %}
-      <div class="scenario card mb-3" id="scenario{{scenario.n}}" {% if not scenario.enabled %}style="display:none;"{% endif %}>
-        <div class="card-header"><h3>{{ _("Scenario") }} {{ scenario.n }}</h3></div>
-        <div class="card-body">
+      <div class="scenario glassmorphic rounded-2xl p-6 md:p-8 flex flex-col space-y-4" id="scenario{{scenario.n}}"{% if not scenario.enabled %}style="display:none;"{% endif %}>
+        <h3 class="text-3xl font-bold text-primary mb-2">Scenario {{ scenario.n }}</h3>
           <div class="mb-3">
-            <label for="scenario{{scenario.n}}_W_input" class="form-label">{{ _("Annual Expenses (W):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Your estimated current annual living expenses for this scenario.") }}</span></span></label>
-            <input type="number" id="scenario{{scenario.n}}_W_input" class="form-control number-input" name="scenario{{scenario.n}}_W" value="{{ request.form.get('scenario{}__W'.format(scenario.n), scenario.W_form) }}" placeholder="{{ _('e.g., 50000') }}" required min="0">
+            <label for="scenario{{scenario.n}}_W_input" class="text-sm font-medium text-secondary block mb-1">{{ _("Annual Expenses (W):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Your estimated current annual living expenses for this scenario.") }}</span></span></label>
+            <input type="number" id="scenario{{scenario.n}}_W_input" class="themed-input form-input w-full p-2 rounded-md border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_W" value="{{ request.form.get('scenario{}__W'.format(scenario.n), scenario.W_form) }}" placeholder="{{ _('e.g., 50000') }}" required min="0">
           </div>
           <div class="mb-3">
-            <label for="scenario{{scenario.n}}_r_input" class="form-label">{{ _("Overall Return (%%) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected average annual investment return for this scenario. Used if no specific periods are defined for this scenario.") }}</span></span></label>
-            <input type="number" id="scenario{{scenario.n}}_r_input" class="form-control number-input" name="scenario{{scenario.n}}_r" step="0.1" value="{{ request.form.get('scenario{}__r'.format(scenario.n), scenario.r_form) }}" placeholder="{{ _('e.g., 7') }}" min="-50" max="100">
+            <label for="scenario{{scenario.n}}_r_input" class="text-sm font-medium text-secondary block mb-1">{{ _("Overall Return (%%) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected average annual investment return for this scenario. Used if no specific periods are defined for this scenario.") }}</span></span></label>
+            <input type="number" id="scenario{{scenario.n}}_r_input" class="themed-input form-input w-full p-2 rounded-md border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_r" step="0.1" value="{{ request.form.get('scenario{}__r'.format(scenario.n), scenario.r_form) }}" placeholder="{{ _('e.g., 7') }}" min="-50" max="100">
           </div>
           <div class="mb-3">
-            <label for="scenario{{scenario.n}}_i_input" class="form-label">{{ _("Overall Inflation (%%) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected average annual inflation rate for this scenario. Used if no specific periods are defined for this scenario.") }}</span></span></label>
-            <input type="number" id="scenario{{scenario.n}}_i_input" class="form-control number-input" name="scenario{{scenario.n}}_i" step="0.1" value="{{ request.form.get('scenario{}__i'.format(scenario.n), scenario.i_form) }}" placeholder="{{ _('e.g., 2') }}" min="-50" max="100">
+            <label for="scenario{{scenario.n}}_i_input" class="text-sm font-medium text-secondary block mb-1">{{ _("Overall Inflation (%%) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected average annual inflation rate for this scenario. Used if no specific periods are defined for this scenario.") }}</span></span></label>
+            <input type="number" id="scenario{{scenario.n}}_i_input" class="themed-input form-input w-full p-2 rounded-md border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_i" step="0.1" value="{{ request.form.get('scenario{}__i'.format(scenario.n), scenario.i_form) }}" placeholder="{{ _('e.g., 2') }}" min="-50" max="100">
           </div>
           <div class="mb-3">
-            <label for="scenario{{scenario.n}}_T_input" class="form-label">{{ _("Total Duration (years) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("How many years retirement funds need to last for this scenario. Used if no specific periods are defined for this scenario.") }}</span></span></label>
-            <input type="number" id="scenario{{scenario.n}}_T_input" class="form-control number-input" name="scenario{{scenario.n}}_T" value="{{ request.form.get('scenario{}__T'.format(scenario.n), scenario.T_form) }}" placeholder="{{ _('e.g., 30') }}" min="1" step="1">
+            <label for="scenario{{scenario.n}}_T_input" class="text-sm font-medium text-secondary block mb-1">{{ _("Total Duration (years) (Fallback):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("How many years retirement funds need to last for this scenario. Used if no specific periods are defined for this scenario.") }}</span></span></label>
+            <input type="number" id="scenario{{scenario.n}}_T_input" class="themed-input form-input w-full p-2 rounded-md border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_T" value="{{ request.form.get('scenario{}__T'.format(scenario.n), scenario.T_form) }}" placeholder="{{ _('e.g., 30') }}" min="1" step="1">
           </div>
 
           <div class="periodic-rates-section mt-3">
-            <h5>{{ _("Periodic Rates (Optional for Scenario") }} {{scenario.n}})</h5>
+            <h5 class="text-lg font-semibold text-primary mt-4 mb-2">{{ _("Periodic Rates (Optional for Scenario") }} {{scenario.n}})</h5>
             {% for k in range(1, 4) %}
             <div class="period-group row gx-2 mb-2"> {# Using Bootstrap row and gx-2 for closer spacing, mb-2 for spacing between periods #}
               <div class="col">
-                <label for="scenario{{scenario.n}}_period{{k}}_duration" class="form-label-sm">{{ _("P") }}{{k}} {{ _("Dur.:") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Duration (in years) for this specific period in this scenario.") }}</span></span></label>
-                <input type="number" class="form-control form-control-sm" name="scenario{{scenario.n}}_period{{k}}_duration" id="scenario{{scenario.n}}_period{{k}}_duration" value="{{ request.form.get('scenario{}period{}_duration'.format(scenario.n, k), scenario.get('period{}_duration_form'.format(k), '')) }}" min="0" step="1" placeholder="{{ _('Years') }}">
+                <label for="scenario{{scenario.n}}_period{{k}}_duration" class="text-xs font-medium text-secondary block mb-0.5">{{ _("P") }}{{k}} {{ _("Dur.:") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Duration (in years) for this specific period in this scenario.") }}</span></span></label>
+                <input type="number" class="themed-input form-input w-full p-1 text-sm rounded border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_period{{k}}_duration" id="scenario{{scenario.n}}_period{{k}}_duration" value="{{ request.form.get('scenario{}period{}_duration'.format(scenario.n, k), scenario.get('period{}_duration_form'.format(k), '')) }}" min="0" step="1" placeholder="{{ _('Years') }}">
               </div>
               <div class="col">
-                <label for="scenario{{scenario.n}}_period{{k}}_r" class="form-label-sm">{{ _("P") }}{{k}} {{ _("Ret(%%):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected annual investment return for this period in this scenario.") }}</span></span></label>
-                <input type="number" class="form-control form-control-sm" name="scenario{{scenario.n}}_period{{k}}_r" id="scenario{{scenario.n}}_period{{k}}_r" step="0.1" value="{{ request.form.get('scenario{}period{}_r'.format(scenario.n, k), scenario.get('period{}_r_form'.format(k), '')) }}" placeholder="%" min="-50" max="100">
+                <label for="scenario{{scenario.n}}_period{{k}}_r" class="text-xs font-medium text-secondary block mb-0.5">{{ _("P") }}{{k}} {{ _("Ret(%%):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected annual investment return for this period in this scenario.") }}</span></span></label>
+                <input type="number" class="themed-input form-input w-full p-1 text-sm rounded border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_period{{k}}_r" id="scenario{{scenario.n}}_period{{k}}_r" step="0.1" value="{{ request.form.get('scenario{}period{}_r'.format(scenario.n, k), scenario.get('period{}_r_form'.format(k), '')) }}" placeholder="%" min="-50" max="100">
               </div>
               <div class="col">
-                <label for="scenario{{scenario.n}}_period{{k}}_i" class="form-label-sm">{{ _("P") }}{{k}} {{ _("Inf(%%):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected annual inflation rate for this period in this scenario.") }}</span></span></label>
-                <input type="number" class="form-control form-control-sm" name="scenario{{scenario.n}}_period{{k}}_i" id="scenario{{scenario.n}}_period{{k}}_i" step="0.1" value="{{ request.form.get('scenario{}period{}_i'.format(scenario.n, k), scenario.get('period{}_i_form'.format(k), '')) }}" placeholder="%" min="-50" max="100">
+                <label for="scenario{{scenario.n}}_period{{k}}_i" class="text-xs font-medium text-secondary block mb-0.5">{{ _("P") }}{{k}} {{ _("Inf(%%):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Expected annual inflation rate for this period in this scenario.") }}</span></span></label>
+                <input type="number" class="themed-input form-input w-full p-1 text-sm rounded border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_period{{k}}_i" id="scenario{{scenario.n}}_period{{k}}_i" step="0.1" value="{{ request.form.get('scenario{}period{}_i'.format(scenario.n, k), scenario.get('period{}_i_form'.format(k), '')) }}" placeholder="%" min="-50" max="100">
               </div>
             </div>
             {% endfor %}
           </div>
 
           <div class="form-group mt-3">
-            <label>{{ _("Withdrawal Timing:") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Choose withdrawal timing for this scenario.") }}</span></span></label>
+            <label class="text-sm font-medium text-secondary block mb-1">{{ _("Withdrawal Timing:") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("Choose withdrawal timing for this scenario.") }}</span></span></label>
             <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="scenario{{scenario.n}}_withdrawal_time" id="scenario{{scenario.n}}_withdrawal_time_start" value="start" {% if request.form.get('scenario{}withdrawal_time'.format(scenario.n), scenario.withdrawal_time_form) == 'start' %}checked{% endif %}>
-                <label class="form-check-label" for="scenario{{scenario.n}}_withdrawal_time_start">{{ _("Start") }}</label>
+                <input class="themed-radio form-radio text-accent-color focus:ring-accent-color bg-transparent border-gray-500" type="radio" name="scenario{{scenario.n}}_withdrawal_time" id="scenario{{scenario.n}}_withdrawal_time_start" value="start" {% if request.form.get('scenario{}withdrawal_time'.format(scenario.n), scenario.withdrawal_time_form) == 'start' %}checked{% endif %}>
+                <label class="form-check-label text-secondary ml-1" for="scenario{{scenario.n}}_withdrawal_time_start">{{ _("Start") }}</label>
             </div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="scenario{{scenario.n}}_withdrawal_time" id="scenario{{scenario.n}}_withdrawal_time_end" value="end" {% if request.form.get('scenario{}withdrawal_time'.format(scenario.n), scenario.withdrawal_time_form) == 'end' %}checked{% endif %}>
-                <label class="form-check-label" for="scenario{{scenario.n}}_withdrawal_time_end">{{ _("End") }}</label>
+                <input class="themed-radio form-radio text-accent-color focus:ring-accent-color bg-transparent border-gray-500" type="radio" name="scenario{{scenario.n}}_withdrawal_time" id="scenario{{scenario.n}}_withdrawal_time_end" value="end" {% if request.form.get('scenario{}withdrawal_time'.format(scenario.n), scenario.withdrawal_time_form) == 'end' %}checked{% endif %}>
+                <label class="form-check-label text-secondary ml-1" for="scenario{{scenario.n}}_withdrawal_time_end">{{ _("End") }}</label>
             </div>
           </div>
           <div class="form-group">
-            <label for="scenario{{scenario.n}}_D">{{ _("Desired Final Portfolio Value ($):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("The amount you wish to have remaining at the end of the duration for this scenario. Default is $0.") }}</span></span></label>
-            <input type="number" class="form-control" name="scenario{{scenario.n}}_D" id="scenario{{scenario.n}}_D" value="{{ request.form.get('scenario{}__D'.format(scenario.n), scenario.D_form) }}" step="any" min="0">
+            <label for="scenario{{scenario.n}}_D" class="text-sm font-medium text-secondary block mb-1">{{ _("Desired Final Portfolio Value ($):") }}<span class="info-icon">&#9432;<span class="tooltip-text">{{ _("The amount you wish to have remaining at the end of the duration for this scenario. Default is $0.") }}</span></span></label>
+            <input type="number" class="themed-input form-input w-full p-2 rounded-md border bg-transparent text-primary border-gray-500 focus:ring-accent-color focus:border-accent-color" name="scenario{{scenario.n}}_D" id="scenario{{scenario.n}}_D" value="{{ request.form.get('scenario{}__D'.format(scenario.n), scenario.D_form) }}" step="any" min="0">
           </div>
           <div class="form-check mt-3">
-            <input type="checkbox" class="form-check-input" name="scenario{{scenario.n}}_enabled" id="scenario{{scenario.n}}_enabled" {% if request.form.get('scenario{}enabled'.format(scenario.n)) == "on" or (not request.form and scenario.enabled) %}checked{% endif %}>
-            <label class="form-check-label" for="scenario{{scenario.n}}_enabled">{{ _("Enable Scenario") }} {{ scenario.n }}</label>
+            <input type="checkbox" class="themed-checkbox form-checkbox text-accent-color focus:ring-accent-color bg-transparent border-gray-500 rounded" name="scenario{{scenario.n}}_enabled" id="scenario{{scenario.n}}_enabled" {% if request.form.get('scenario{}enabled'.format(scenario.n)) == "on" or (not request.form and scenario.enabled) %}checked{% endif %}>
+            <label class="form-check-label text-secondary ml-1" for="scenario{{scenario.n}}_enabled">{{ _("Enable Scenario") }} {{ scenario.n }}</label>
           </div>
 
-          {# Display error for this specific scenario if it exists #}
-          {% if scenario.error %}
-            <div class="alert alert-warning mt-2 p-2">{{ scenario.error }}</div> {# Error messages from backend are already translated #}
-          {% endif %}
-
-          <div class="result-section mt-2"> {# For AJAX updated FIRE number #}
-            {% if scenario.fire_number_display and scenario.fire_number_display != "N/A" and not scenario.error %}
-              <p><strong>{{ _("FIRE Number:") }}</strong> {{ scenario.fire_number_display }}</p>
+          <div class="scenario-results-area mt-auto pt-4 border-t" style="border-color: rgba(var(--border-color), 0.3);">
+            {% if scenario.error %}
+            <div class="text-red-500 text-sm p-2 rounded bg-red-500/10">{{ scenario.error }}</div>
+            {% elif scenario.fire_number_display and scenario.fire_number_display != "N/A" %}
+            <div>
+                <p class="text-sm font-medium text-secondary">{{ _("FIRE Number") }}</p>
+                <p class="text-2xl font-bold" style="color: var(--accent-color);">{{ scenario.fire_number_display }}</p>
+            </div>
             {% endif %}
           </div>
-        </div>
       </div>
       {% endfor %}
     </div>
-    <button type="submit" class="btn btn-primary mt-3">{{ _("Compare Scenarios") }}</button> {# Changed from input to button #}
+    <button type="submit" id="compare-scenarios-button" class="btn-primary py-3 px-6 rounded-lg font-semibold text-lg inline-block mt-8">{{ _("Compare Scenarios") }}</button>
   </form>
 
-  <div id="summaryTableContainer" class="mt-4"> {# Added container for styling #}
-    <h3>{{ _("Comparison Summary") }}</h3>
+  <div class="glassmorphic rounded-2xl p-6 md:p-8 mt-12">
+    <h2 class="text-2xl font-bold text-primary text-center mb-6">{{ _("Comparison Summary") }}</h2>
     <div id="summaryTable" class="table-responsive"></div> {# Added table-responsive #}
   </div>
 
-  <div id="combinedGraphs" class="mt-4">
+  <div class="glassmorphic rounded-2xl p-6 md:p-8 mt-12">
     {% if combined_balance and combined_withdrawal %}
-      <h3>{{ _("Combined Portfolio Balance") }}</h3>
+      <h3 class="text-xl font-bold text-primary mb-3">{{ _("Combined Portfolio Balance") }}</h3>
       <div id="combined_balance">{{ combined_balance|safe }}</div>
-      <h3>{{ _("Combined Annual Withdrawals") }}</h3>
+      <h3 class="text-xl font-bold text-primary mb-3">{{ _("Combined Annual Withdrawals") }}</h3>
       <div id="combined_withdrawal">{{ combined_withdrawal|safe }}</div>
     {% endif %}
   </div>
@@ -128,9 +130,8 @@
   {% endif %}
 
   <div class="mt-4"> {# Added spacing for back link #}
-    <a href="{{ url_for('project.index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
+    <a href="{{ url_for('project.index') }}" class="text-accent-color hover:underline font-medium inline-block mt-8">{{ _("← Back to Calculator") }}</a>
   </div>
-</div>
 {% endblock %}
 
 {% block scripts_extra %}
@@ -156,10 +157,10 @@
       // Make scenarios sortable if jQuery UI is loaded
       if (typeof $.fn.sortable === 'function') {
         $(".scenario-container").sortable({
-            placeholder: "ui-state-highlight card mb-3", // Use card classes for placeholder
+            placeholder: "ui-state-highlight glassmorphic rounded-2xl p-6 md:p-8 mb-3", // Use new classes
             forcePlaceholderSize: true,
-            axis: "y",
-            handle: ".card-header" // Allow dragging by the card header
+            axis: "y", // Keep vertical axis for now with grid
+            // handle: ".card-header" // Card header is removed, consider a new handle or remove if grid drag conflicts
         });
       }
       loadScenarioOptions();
@@ -235,12 +236,12 @@
               $("#summaryTable").html("");   // Clear table
               alert(response.message); // Already translated from backend
               // Potentially clear individual scenario results if a global message indicates total failure
-               $(".scenario .result-section").remove();
-               $(".scenario .alert.alert-warning.error-message").remove();
+               $(".scenario .scenario-results-area").html(''); // Clear specific results area
+               $(".scenario .alert.alert-warning").remove(); // Remove old error messages
           } else if (response.scenarios && response.scenarios.length > 0) {
               $("#combinedGraphs").html(''); // Clear previous graphs before adding new ones
               try {
-                  const balanceContent = "<h3>Combined Portfolio Balance</h3>" +
+                  const balanceContent = "<h3 class=\"text-xl font-bold text-primary mb-3\">Combined Portfolio Balance</h3>" +
                                      (response.combined_balance || "<p>No balance graph data.</p>");
                   $("#combinedGraphs").append(balanceContent);
                   console.log('[CompareDebug] Updated combined balance graph section.');
@@ -250,7 +251,7 @@
               }
 
               try {
-                  const withdrawalContent = "<h3>Combined Annual Withdrawals</h3>" +
+                  const withdrawalContent = "<h3 class=\"text-xl font-bold text-primary mb-3\">Combined Annual Withdrawals</h3>" +
                                         (response.combined_withdrawal || "<p>No withdrawal graph data.</p>");
                   $("#combinedGraphs").append(withdrawalContent);
                   console.log('[CompareDebug] Updated combined withdrawal graph section.');
@@ -281,13 +282,16 @@
                           console.warn('[CompareDebug] Scenario div not found for scenario number:', (sc.n || index + 1));
                           return;
                       }
-                      scenarioDiv.find(".result-section").remove();
-                      scenarioDiv.find(".alert.alert-warning.error-message").remove(); // More specific selector
+                      // Clear previous results and errors for this specific scenario
+                      scenarioDiv.find(".scenario-results-area").html('');
+                      scenarioDiv.find(".alert.alert-warning").remove(); // Remove old error messages if any
+
                       if(sc.error){
-                          scenarioDiv.append('<div class="alert alert-warning mt-2 p-2 error-message">' + sc.error + '</div>');
+                          scenarioDiv.find(".scenario-results-area").append('<div class="text-red-500 text-sm p-2 rounded bg-red-500/10">' + sc.error + '</div>');
                       } else if (sc.fire_number_display && sc.fire_number_display !== "N/A") {
-                          var resultHtml = '<div class="result-section mt-2"><p><strong>FIRE Number:</strong> ' + sc.fire_number_display + '</p></div>';
-                          scenarioDiv.append(resultHtml);
+                          var resultHtml = '<div><p class="text-sm font-medium text-secondary">' + _("FIRE Number") + '</p>' +
+                                           '<p class="text-2xl font-bold" style="color: var(--accent-color);">' + sc.fire_number_display + '</p></div>';
+                          scenarioDiv.find(".scenario-results-area").append(resultHtml);
                       }
                   });
                   console.log('[CompareDebug] Individual scenario updates attempted.');
@@ -306,31 +310,31 @@
     }
     
     function updateSummaryTable(scenarios) {
-      console.log('[CompareDebug] updateSummaryTable() called with scenarios:', scenarios);
-      var html = "<table class='table table-striped table-hover'><thead><tr><th>#</th><th>W</th><th>Rates & Dur.</th><th>Timing</th><th>FIRE #</th><th>Error</th></tr></thead><tbody>";
-      scenarios.forEach(function(sc) {
-        let rates_display = "N/A";
-        if (sc.rates_periods_data && sc.rates_periods_data.length > 0) {
-            if (sc.rates_periods_data.length === 1) {
-                let p = sc.rates_periods_data[0];
-                rates_display = "R:" + ` ${(p.r * 100).toFixed(1)}%, ` + "I:" + ` ${(p.i * 100).toFixed(1)}%, ` + "T:" + ` ${p.duration}y`;
-            } else {
-                rates_display = sc.rates_periods_data.map(p => `(R:${(p.r*100).toFixed(1)}% I:${(p.i*100).toFixed(1)}% D:${p.duration}y)`).join('<br>');
+        console.log('[CompareDebug] updateSummaryTable() called with scenarios:', scenarios);
+        var html = "<table class='w-full text-sm text-left text-primary table table-striped table-hover'><thead><tr class='text-xs text-secondary uppercase bg-black/10'><th class='py-3 px-4'>#</th><th class='py-3 px-4'>W</th><th class='py-3 px-4'>Rates & Dur.</th><th class='py-3 px-4'>Timing</th><th class='py-3 px-4'>FIRE #</th><th class='py-3 px-4'>Error</th></tr></thead><tbody>";
+        scenarios.forEach(function(sc) {
+            let rates_display = "N/A";
+            if (sc.rates_periods_data && sc.rates_periods_data.length > 0) {
+                if (sc.rates_periods_data.length === 1) {
+                    let p = sc.rates_periods_data[0];
+                    rates_display = "R:" + ` ${(p.r * 100).toFixed(1)}%, ` + "I:" + ` ${(p.i * 100).toFixed(1)}%, ` + "T:" + ` ${p.duration}y`;
+                } else {
+                    rates_display = sc.rates_periods_data.map(p => `(R:${(p.r*100).toFixed(1)}% I:${(p.i*100).toFixed(1)}% D:${p.duration}y)`).join('<br>');
+                }
+            } else { // Fallback if rates_periods_data not directly in scenario object, use form values
+                rates_display = "R:" + ` ${sc.r_form}%, ` + "I:" + ` ${sc.i_form}%, ` + "T:" + ` ${sc.T_form}y`;
             }
-        } else { // Fallback if rates_periods_data not directly in scenario object, use form values
-            rates_display = "R:" + ` ${sc.r_form}%, ` + "I:" + ` ${sc.i_form}%, ` + "T:" + ` ${sc.T_form}y`;
-        }
 
-        html += "<tr><td>" + sc.n + "</td>" +
-                "<td>" + (sc.W_form || 'N/A') + "</td>" +
-                "<td>" + rates_display + "</td>" +
-                "<td>" + (sc.withdrawal_time_form || 'N/A') + "</td>" +
-                "<td>" + (sc.fire_number_display || "N/A") + "</td>" +
-                "<td class='text-danger'>" + (sc.error || "") + "</td></tr>"; // Errors already translated
-      });
-      html += "</tbody></table>";
-      $("#summaryTable").html(html);
-      console.log('[CompareDebug] Generated summary table HTML:', html);
+            html += "<tr><td class='py-3 px-4'>" + sc.n + "</td>" +
+                    "<td class='py-3 px-4'>" + (sc.W_form || 'N/A') + "</td>" +
+                    "<td class='py-3 px-4'>" + rates_display + "</td>" +
+                    "<td class='py-3 px-4'>" + (sc.withdrawal_time_form || 'N/A') + "</td>" +
+                    "<td class='py-3 px-4'>" + (sc.fire_number_display || "N/A") + "</td>" +
+                    "<td class='py-3 px-4 text-danger'>" + (sc.error || "") + "</td></tr>"; // Errors already translated
+        });
+        html += "</tbody></table>";
+        $("#summaryTable").html(html);
+        console.log('[CompareDebug] Generated summary table HTML:', html);
     }
     
     // Removed bindScenarioSync as AJAX updates are now manual via button.

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,33 +3,30 @@
 {% block title %}{{ _("FIRE Calculator - Home") }}{% endblock %}
 
 {% block content %}
-  <div class="container index-page text-center"> {# Added text-center for centering content #}
-    <h2>{{ _("Plan Your Financial Independence") }}</h2>
+<div class="glassmorphic rounded-2xl p-6 md:p-8 text-center">
+    <h2 class="text-4xl md:text-5xl font-extrabold text-primary tracking-tight mb-4">{{ _("Plan Your Financial Independence") }}</h2>
 
     {% if error %} {# Keep error display for any general messages if needed #}
       <div class="alert alert-danger">{{ error }}</div>
     {% endif %}
 
-    <p class="lead mt-4">{{ _("Ready to map out your journey to financial independence? Our new step-by-step wizard will guide you through entering your expenses, expected returns, and any one-off financial events.") }}</p>
+    <p class="mt-4 max-w-2xl mx-auto text-lg text-secondary">{{ _("Ready to map out your journey to financial independence? Our new step-by-step wizard will guide you through entering your expenses, expected returns, and any one-off financial events.") }}</p>
 
     <div class="mt-4 mb-4"> {# Added margin for spacing #}
-      <a href="{{ url_for('wizard_bp.wizard_expenses_step') }}" class="btn btn-primary btn-lg">
+      <a href="{{ url_for('wizard_bp.wizard_expenses_step') }}" class="btn-primary py-3 px-6 rounded-lg font-semibold text-lg inline-block mt-8">
         {{ _("Start the FIRE Wizard") }}
       </a>
     </div>
 
-    <p>{{ _("The wizard makes it easier to enter your details and ensures everything is validated along the way.") }}</p>
+    <p class="text-secondary mt-4 max-w-xl mx-auto">{{ _("The wizard makes it easier to enter your details and ensures everything is validated along the way.") }}</p>
 
-    <hr class="my-4"> {# A thematic break #}
+    <hr class="my-8 border-t" style="border-color: rgba(var(--border-color), 0.3);"> {# A thematic break #}
 
-    <h4>{{ _("Other Tools") }}</h4>
+    <h3 class="text-2xl font-bold text-primary mt-8 mb-4">{{ _("Other Tools") }}</h3>
     <div class="mt-3">
-      <a href="{{ url_for('project.compare') }}" class="btn btn-secondary">{{ _("Compare Scenarios") }}</a>
+      <a href="{{ url_for('project.compare') }}" class="text-accent-color hover:underline font-medium text-lg">{{ _("Compare Scenarios") }}</a>
       {# Add other links here if necessary, e.g., to a direct calculation if some simplified default data model were to be kept, but current plan replaces it. #}
     </div>
 
-  </div>
-
-  {# Remove the old JavaScript for one-off events; it's no longer needed here. #}
-  {# The <script> block related to 'one_off_events_container' should be deleted. #}
+</div>
 {% endblock %}


### PR DESCRIPTION
This commit introduces the first phase of the UI refresh, focusing on core styling, base layout, and initial page restyling.

Key changes:
- Extracted and integrated a new theming system from reference HTML:
  - Includes 10 distinct color themes, each with light and dark modes (20 total combinations).
  - CSS variables for colors, fonts ('Inter'), gradients, and glassmorphism effects are defined in `static/css/main.css`.
  - Old Bootstrap theme variables (`:root`, `[data-bs-theme="dark"]`) removed.
- Updated `templates/base.html`:
  - New navigation bar matching reference style, with updated links.
  - New footer matching reference style.
  - Integrated HTML for a theme settings modal, accessible from the new navbar, allowing theme/mode changes without page navigation.
  - Global `body` styles (font, background) updated in `static/css/main.css`.
- Updated `static/js/theme.js`:
  - Replaced with new logic to manage the 10 themes, light/dark modes, and settings modal interactions.
  - Loads your preferences from localStorage.
- Restyled `templates/index.html`:
  - Applied glassmorphic container and updated typography/button styles.
- Restyled `templates/compare.html` (HTML Structure):
  - Major structural update with a new page header.
  - Scenario input sections are now cards with glassmorphic styling, arranged in a responsive grid.
  - Introduced conceptual CSS classes (e.g., `themed-input`) for form elements and tables; CSS definitions for these are pending.

The settings modal is available on all pages extending base.html and supports all 20 theme combinations as requested in recent feedback. Next steps involve defining CSS for new form classes on the compare page and then restyling wizard and other remaining pages.