### PR TITLE
feat: Restyle Wizard Pages and About Page with New Theme

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -835,3 +835,189 @@ header h1 a:hover {
   visibility: visible;
   opacity: 1;
 }
+
+
+/* --- Themed Form Styles for Compare Page --- */
+.themed-input, .themed-select {
+    background-color: rgba(var(--bg-secondary-rgb), 0.2); /* Slightly more subtle background */
+    color: var(--text-primary);
+    border: 1px solid rgba(var(--border-color), 0.4);
+    border-radius: 0.375rem; /* Corresponds to rounded-md */
+    padding: 0.6rem 0.8rem; /* Adjusted padding */
+    width: 100%;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    font-size: 0.95rem; /* Slightly smaller font for inputs */
+}
+
+.themed-input:focus, .themed-select:focus {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--accent-color) 30%, transparent);
+    outline: 0;
+    background-color: rgba(var(--bg-secondary-rgb), 0.3); /* Slightly darken on focus */
+}
+
+.themed-select {
+    appearance: none; /* Basic reset */
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e"); /* Basic arrow, color needs to adapt */
+    background-repeat: no-repeat;
+    background-position: right 0.75rem center;
+    background-size: 16px 12px;
+}
+
+/* Adapting select arrow color - this is tricky. The SVG fill needs to change. */
+/* For now, this might not perfectly theme the arrow color but is a start. */
+[data-mode='dark'] .themed-select {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23cccccc' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+}
+
+
+.themed-radio, .themed-checkbox {
+    accent-color: var(--accent-color);
+    background-color: transparent;
+    border: 1px solid rgba(var(--border-color), 0.4);
+    width: 1.1em;
+    height: 1.1em;
+    vertical-align: middle;
+}
+.themed-radio:focus, .themed-checkbox:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
+/* --- Themed Table Styles for Compare Page Summary --- */
+.compare-summary-table {
+    width: 100%;
+    text-align: left;
+    border-collapse: collapse;
+    margin-top: 1rem; /* Add some margin above the table */
+    font-size: 0.9rem;
+}
+
+.compare-summary-table th {
+    color: var(--text-secondary);
+    background-color: rgba(var(--bg-secondary-rgb), 0.05); /* Very subtle background for header */
+    padding: 0.8rem 1rem;
+    border-bottom: 2px solid var(--accent-color); /* Accent border for header bottom */
+    font-weight: 600; /* Semibold for headers */
+}
+
+.compare-summary-table td {
+    color: var(--text-primary);
+    padding: 0.8rem 1rem;
+    border-bottom: 1px solid rgba(var(--border-color), 0.2);
+}
+
+.compare-summary-table tbody tr:last-child td {
+    border-bottom: none; /* Remove border for the last row */
+}
+
+.compare-summary-table tbody tr:hover {
+    background-color: rgba(var(--bg-secondary-rgb), 0.1); /* Hover effect for rows */
+}
+
+/* --- Info Icon Tooltip Theming --- */
+.info-icon {
+    color: var(--text-secondary); /* Ensure info icon itself uses theme color */
+}
+
+.info-icon .tooltip-text {
+  background-color: var(--bg-secondary-rgb); /* Use a theme background */
+  color: var(--text-primary); /* Use theme text color */
+  border: 1px solid rgba(var(--border-color), 0.3);
+  box-shadow: 0 4px 12px rgba(var(--shadow-color), 0.2); /* Use theme shadow */
+  border-radius: 0.375rem; /* rounded-md */
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: normal; /* Explicitly set from bold in original */
+}
+
+/* Override Bootstrap's default form-control focus glow if still present on some elements accidentally */
+.form-control:focus {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--accent-color) 30%, transparent);
+}
+
+/* Style for select elements used in scenario-header */
+.scenario-header select.form-select {
+    background-color: rgba(var(--bg-secondary-rgb), 0.2) !important; /* Important to override Bootstrap if needed */
+    color: var(--text-primary) !important;
+    border: 1px solid rgba(var(--border-color), 0.4) !important;
+    padding: 0.375rem 2.25rem 0.375rem 0.75rem !important; /* Bootstrap default padding */
+}
+.scenario-header select.form-select:focus {
+    border-color: var(--accent-color) !important;
+    box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--accent-color) 30%, transparent) !important;
+}
+
+/* Ensure .form-label in compare.html also uses themed text color */
+.form-label {
+    color: var(--text-secondary);
+}
+
+/* Styling for the periodic rate input groups to have less margin */
+.period-group.row {
+    margin-bottom: 0.5rem !important; /* Reduce default Bootstrap row margin */
+}
+.period-group .col {
+    padding-left: 0.25rem !important;
+    padding-right: 0.25rem !important;
+}
+
+/* --- Secondary Button Style --- */
+.btn-secondary {
+    background-color: transparent;
+    color: var(--text-primary);
+    border: 1px solid rgba(var(--border-color), 0.5);
+    padding: 0.5rem 1.25rem; /* Default padding */
+    border-radius: 0.375rem; /* rounded-md */
+    font-weight: 600; /* semibold */
+    text-align: center;
+    transition: all 0.2s ease-in-out;
+    display: inline-block; /* Ensure it behaves like a button */
+    cursor: pointer;
+}
+
+.btn-secondary:hover {
+    background-color: var(--accent-color);
+    color: var(--accent-text);
+    border-color: var(--accent-color);
+}
+
+.btn-secondary.text-xs { /* For smaller secondary buttons like remove item */
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+}
+
+/* --- Themed Range Slider --- */
+.themed-range {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 0.5rem; /* 8px */
+    border-radius: 0.25rem; /* rounded-sm */
+    background-color: rgba(var(--border-color), 0.3);
+    outline: none;
+    opacity: 0.9;
+    transition: opacity .15s ease-in-out;
+}
+.themed-range:hover {
+    opacity: 1;
+}
+.themed-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 1.25rem; /* 20px */
+    height: 1.25rem; /* 20px */
+    border-radius: 50%;
+    background-color: var(--accent-color);
+    cursor: pointer;
+    border: 2px solid rgba(var(--bg-secondary-rgb),0.7); /* Light border for thumb */
+}
+.themed-range::-moz-range-thumb {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    background-color: var(--accent-color);
+    cursor: pointer;
+    border: 2px solid rgba(var(--bg-secondary-rgb),0.7);
+}

--- a/templates/_formhelpers.html
+++ b/templates/_formhelpers.html
@@ -1,9 +1,9 @@
 {% macro render_field(field, class="form-control", placeholder="") %}
   <div class="mb-3">
-    {{ field.label(class="form-label") }}
-    {{ field(class=class ~ (' is-invalid' if field.errors else ''), placeholder=placeholder, **kwargs) }}
+    {{ field.label(class="text-sm font-medium text-secondary block mb-1") }}
+    {{ field(class=(class if class != "form-control" else "themed-input") ~ (' is-invalid' if field.errors else ''), placeholder=placeholder, **kwargs) }}
     {% if field.errors %}
-      <div class="invalid-feedback">
+      <div class="text-red-500 text-xs mt-1">
         {% for error in field.errors %}
           <span>{{ error }}</span><br>
         {% endfor %}
@@ -15,20 +15,20 @@
   </div>
 {% endmacro %}
 
-{% macro render_submit_field(field, class="btn btn-primary", formnovalidate=False) %}
+{% macro render_submit_field(field, class="btn-primary py-2 px-5 rounded-md font-semibold text-base", formnovalidate=False) %}
   {{ field(class=class, formnovalidate=formnovalidate if formnovalidate else None) }}
 {% endmacro %}
 
 {% macro render_field_list_item(form_entry, index, list_name, field_names) %}
-<div class="border p-3 mb-3 rounded list-item-entry" id="{{ list_name }}-{{ index }}-entry">
+<div class="bg-white/5 p-4 mb-3 rounded-lg border border-[rgba(var(--border-color),0.2)] list-item-entry shadow-sm" id="{{ list_name }}-{{ index }}-entry">
     <div class="d-flex justify-content-between align-items-center">
         <h5>{{ list_name.replace('_', ' ').title() }} #{{ index + 1 }}</h5>
-        <button type="button" class="btn btn-danger btn-sm remove-list-item-btn" data-entry-id="{{ list_name }}-{{ index }}-entry" aria-label="{{ _('Remove this item') }}">&times;</button>
+        <button type="button" class="btn-secondary text-xs py-1 px-2 rounded-md font-semibold remove-list-item-btn" data-entry-id="{{ list_name }}-{{ index }}-entry" aria-label="{{ _('Remove this item') }}">&times;</button>
     </div>
     <input type="hidden" name="{{ list_name }}-{{ index }}-csrf_token" value="{{ form_entry.csrf_token.current_token }}">
     {% for field_name in field_names %}
         {% set field = form_entry[field_name] %}
-        {{ render_field(field, class="form-control form-control-sm", placeholder=field.label.text) }}
+        {{ render_field(field, class="themed-input text-sm p-1.5", placeholder=field.label.text) }}
     {% endfor %}
 </div>
 {% endmacro %}

--- a/templates/about.html
+++ b/templates/about.html
@@ -3,20 +3,20 @@
 {% block title %}{{ _("About - FIRE Calculator") }}{% endblock %}
 
 {% block content %}
-<div class="container content-page"> {# Using a generic 'content-page' class for potential styling #}
-  <h2>{{ _("About the FIRE Calculator") }}</h2>
-  <p>{{ _("This FIRE (Financial Independence, Retire Early) Calculator is a tool designed to help you explore various financial scenarios related to long-term planning and retirement.") }}</p>
-  <p>{{ _("Key features include:") }}</p>
-  <ul>
+<div class="glassmorphic rounded-2xl p-6 md:p-10 shadow-xl mx-auto max-w-3xl text-secondary">
+  <h1 class="text-3xl md:text-4xl font-bold text-primary text-center mb-8">{{ _("About the FIRE Calculator") }}</h1>
+  <p class="mb-4 leading-relaxed">{{ _("This FIRE (Financial Independence, Retire Early) Calculator is a tool designed to help you explore various financial scenarios related to long-term planning and retirement.") }}</p>
+  <p class="mb-4 leading-relaxed">{{ _("Key features include:") }}</p>
+  <ul class="list-disc list-inside space-y-2 mb-4 pl-4">
     <li>{{ _("Calculating required retirement portfolios based on desired annual expenses.") }}</li>
     <li>{{ _("Estimating sustainable annual withdrawals from a given portfolio size.") }}</li>
     <li>{{ _("Modeling the effects of different investment return rates, inflation rates, and retirement durations.") }}</li>
     <li>{{ _("Support for multi-period analysis, allowing you to define different financial conditions for different phases of your plan.") }}</li>
     <li>{{ _("Comparing multiple scenarios side-by-side to understand the impact of various assumptions.") }}</li>
   </ul>
-  <p>{{ _("Whether you are just starting to think about financial independence or are well on your way, this calculator aims to provide valuable insights. Remember that all calculations are based on the inputs you provide and are for informational purposes only. Financial planning is complex, and it's recommended to consult with a qualified financial advisor for personalized advice.") }}</p>
-  <div class="mt-4">
-    <a href="{{ url_for('project.index') }}" class="btn btn-outline-secondary">{{ _("← Back to Calculator") }}</a>
+  <p class="mb-4 leading-relaxed">{{ _("Whether you are just starting to think about financial independence or are well on your way, this calculator aims to provide valuable insights. Remember that all calculations are based on the inputs you provide and are for informational purposes only. Financial planning is complex, and it's recommended to consult with a qualified financial advisor for personalized advice.") }}</p>
+  <div class="text-center mt-8">
+    <a href="{{ url_for('project.index') }}" class="btn-secondary py-2 px-4 rounded-md font-semibold text-sm inline-block">{{ _("← Back to Calculator") }}</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/wizard_expenses.html
+++ b/templates/wizard_expenses.html
@@ -4,24 +4,50 @@
 {% block title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block content %}
-  <h2>{{ title }}</h2>
-  <p>{{ _("Please enter your current annual expenses. This will help us understand your baseline financial needs.") }}</p>
-  <form method="POST" action="{{ url_for('wizard_bp.wizard_expenses_step') }}" novalidate>
-    {{ form.csrf_token }}
-    <fieldset>
-      <legend class="visually-hidden">{{ _("Expenses Form") }}</legend>
-      {{ render_field(form.annual_expenses, class="form-control", placeholder=_("e.g., 50000")) }}
-      {{ render_field(form.housing, class="form-control", placeholder=_("e.g., 15000")) }}
-      {{ render_field(form.food, class="form-control", placeholder=_("e.g., 6000")) }}
-      {{ render_field(form.transportation, class="form-control", placeholder=_("e.g., 5000")) }}
-      {{ render_field(form.utilities, class="form-control", placeholder=_("e.g., 3000")) }}
-      {{ render_field(form.personal_care, class="form-control", placeholder=_("e.g., 2000")) }}
-      {{ render_field(form.entertainment, class="form-control", placeholder=_("e.g., 4000")) }}
-      {{ render_field(form.healthcare, class="form-control", placeholder=_("e.g., 3000")) }}
-      {{ render_field(form.other_expenses, class="form-control", placeholder=_("e.g., 1000")) }}
-    </fieldset>
-    {{ render_submit_field(form.submit, class="btn btn-primary mt-3") }}
-  </form>
+<div class="mb-12 max-w-3xl mx-auto">
+    <h2 class="text-center text-2xl md:text-3xl font-bold text-primary mb-2">{{ _("Calculation Wizard") }}</h2>
+    <p class="text-center text-secondary mb-6">{{ _("Follow the steps to get your FIRE projection.") }}</p>
+    <div class="w-full glassmorphic rounded-full h-2.5 p-0.5"> {# Reduced padding on progress bar itself #}
+        <div class="h-full rounded-full" style="width: 20%; background-color: var(--accent-color);"></div> {# Adjusted width for 5 steps total if summary is a step #}
+    </div>
+    <ol class="flex justify-between text-sm mt-2 px-1">
+        <li class="font-bold text-primary">{{ _("Expenses") }}</li>
+        <li class="text-secondary">{{ _("Rates") }}</li>
+        <li class="text-secondary">{{ _("One-Offs") }}</li>
+        <li class="text-secondary">{{ _("Results") }}</li>
+        <li class="text-secondary">{{ _("Summary") }}</li>
+    </ol>
+</div>
+
+<div class="glassmorphic p-6 md:p-10 rounded-2xl shadow-xl mx-auto max-w-3xl">
+    <h3 class="text-2xl md:text-3xl font-bold text-primary text-center mb-3">{{ title }}</h3>
+    <p class="text-secondary text-center mb-8">{{ _("Please enter your current annual expenses. This will help us understand your baseline financial needs.") }}</p>
+    <form method="POST" action="{{ url_for('wizard_bp.wizard_expenses_step') }}" novalidate class="space-y-6">
+        {{ form.csrf_token }}
+        <fieldset>
+            <legend class="visually-hidden">{{ _("Expenses Form") }}</legend>
+
+            {{ render_field(form.annual_expenses, placeholder=_("e.g., 50000")) }}
+
+            <div class="pt-4 mt-4 border-t" style="border-color: rgba(var(--border-color), 0.2);">
+                <p class="text-sm text-secondary mb-4">{{_("Optional: Provide an itemized breakdown below. The total will be calculated automatically if 'Annual Expenses' is left blank or is zero.")}}</p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+                    {{ render_field(form.housing, placeholder=_("e.g., 15000")) }}
+                    {{ render_field(form.food, placeholder=_("e.g., 6000")) }}
+                    {{ render_field(form.transportation, placeholder=_("e.g., 5000")) }}
+                    {{ render_field(form.utilities, placeholder=_("e.g., 3000")) }}
+                    {{ render_field(form.personal_care, placeholder=_("e.g., 2000")) }}
+                    {{ render_field(form.entertainment, placeholder=_("e.g., 4000")) }}
+                    {{ render_field(form.healthcare, placeholder=_("e.g., 3000")) }}
+                    {{ render_field(form.other_expenses, placeholder=_("e.g., 1000")) }}
+                </div>
+            </div>
+        </fieldset>
+        <div class="flex justify-end items-center pt-6 mt-6 border-t" style="border-color: rgba(var(--border-color), 0.3);">
+            {{ render_submit_field(form.submit, class="btn-primary py-2 px-5 rounded-md font-semibold text-base") }}
+        </div>
+    </form>
+</div>
 {% endblock %}
 
 {% block scripts_extra %}

--- a/templates/wizard_one_offs.html
+++ b/templates/wizard_one_offs.html
@@ -4,33 +4,53 @@
 {% block title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block content %}
-  <h2>{{ title }}</h2>
-  <p>{{ _("List any significant one-time expenses (e.g., buying a car, wedding) or incomes (e.g., inheritance, sale of asset) you anticipate.") }}</p>
-  <form method="POST" action="{{ url_for('wizard_bp.wizard_one_offs_step') }}" novalidate>
-    {{ form.csrf_token }}
+<div class="mb-12 max-w-3xl mx-auto">
+    <h2 class="text-center text-2xl md:text-3xl font-bold text-primary mb-2">{{ _("Calculation Wizard") }}</h2>
+    <p class="text-center text-secondary mb-6">{{ _("Follow the steps to get your FIRE projection.") }}</p>
+    <div class="w-full glassmorphic rounded-full h-2.5 p-0.5">
+        <div class="h-full rounded-full" style="width: 60%; background-color: var(--accent-color);"></div> {# Step 3 of 5 = 60% #}
+    </div>
+    <ol class="flex justify-between text-sm mt-2 px-1">
+        <li class="text-secondary">{{ _("Expenses") }}</li>
+        <li class="text-secondary">{{ _("Rates") }}</li>
+        <li class="font-bold text-primary">{{ _("One-Offs") }}</li>
+        <li class="text-secondary">{{ _("Results") }}</li>
+        <li class="text-secondary">{{ _("Summary") }}</li>
+    </ol>
+</div>
 
-    <fieldset class="mb-3">
-      <legend>{{ _("Large One-Off Expenses") }}</legend>
-      <div id="large-expenses-list">
-        {% for expense_form in form.large_expenses %}
-         {{ render_field_list_item(expense_form, loop.index0, 'large_expenses', ['year', 'amount', 'description']) }}
-        {% endfor %}
-      </div>
-      {{ render_submit_field(form.submit_add_expense, class="btn btn-secondary btn-sm mt-2", formnovalidate=True) }}
-    </fieldset>
+<div class="glassmorphic p-6 md:p-10 rounded-2xl shadow-xl mx-auto max-w-3xl">
+    <h3 class="text-2xl md:text-3xl font-bold text-primary text-center mb-3">{{ title }}</h3>
+    <p class="text-secondary text-center mb-8">{{ _("List any significant one-time expenses (e.g., buying a car, wedding) or incomes (e.g., inheritance, sale of asset) you anticipate.") }}</p>
+    <form method="POST" action="{{ url_for('wizard_bp.wizard_one_offs_step') }}" novalidate class="space-y-8"> {# Increased spacing between fieldsets #}
+        {{ form.csrf_token }}
 
-    <fieldset>
-      <legend>{{ _("Large One-Off Incomes") }}</legend>
-      <div id="large-incomes-list">
-        {% for income_form in form.large_incomes %}
-          {{ render_field_list_item(income_form, loop.index0, 'large_incomes', ['year', 'amount', 'description']) }}
-        {% endfor %}
-      </div>
-      {{ render_submit_field(form.submit_add_income, class="btn btn-secondary btn-sm mt-2", formnovalidate=True) }}
-    </fieldset>
+        <fieldset> {# First fieldset, no top border needed #}
+          <legend class="text-xl font-semibold text-primary mb-4">{{ _("Large One-Off Expenses") }}</legend>
+          <div id="large-expenses-list" class="space-y-4"> {# Spacing for items #}
+            {% for expense_form in form.large_expenses %}
+             {{ render_field_list_item(expense_form, loop.index0, 'large_expenses', ['year', 'amount', 'description']) }}
+            {% endfor %}
+          </div>
+          {{ render_submit_field(form.submit_add_expense, class="btn-secondary text-sm py-1.5 px-4 rounded-md font-semibold mt-4", formnovalidate=True) }}
+        </fieldset>
 
-    {{ render_submit_field(form.submit, class="btn btn-primary mt-4") }}
-  </form>
+        <fieldset class="pt-6 border-t border-[rgba(var(--border-color),0.2)]"> {# Subsequent fieldsets get a top border #}
+          <legend class="text-xl font-semibold text-primary mb-4">{{ _("Large One-Off Incomes") }}</legend>
+          <div id="large-incomes-list" class="space-y-4"> {# Spacing for items #}
+            {% for income_form in form.large_incomes %}
+              {{ render_field_list_item(income_form, loop.index0, 'large_incomes', ['year', 'amount', 'description']) }}
+            {% endfor %}
+          </div>
+          {{ render_submit_field(form.submit_add_income, class="btn-secondary text-sm py-1.5 px-4 rounded-md font-semibold mt-4", formnovalidate=True) }}
+        </fieldset>
+
+        <div class="flex justify-between items-center pt-8 mt-8 border-t" style="border-color: rgba(var(--border-color), 0.3);">
+            <a href="{{ url_for('wizard_bp.wizard_rates_step') }}" class="btn-secondary py-2 px-5 rounded-md font-semibold text-base">{{ _("Previous") }}</a>
+            {{ render_submit_field(form.submit, class="btn-primary py-2 px-5 rounded-md font-semibold text-base") }}
+        </div>
+    </form>
+</div>
 {% endblock %}
 
 {% block scripts_extra %}

--- a/templates/wizard_rates.html
+++ b/templates/wizard_rates.html
@@ -4,46 +4,73 @@
 {% block title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block content %}
-  <h2>{{ title }}</h2>
-  <p>{{ _("Define your expected investment returns and inflation. You can also specify different return rates for distinct periods if needed.") }}</p>
-  <form method="POST" action="{{ url_for('wizard_bp.wizard_rates_step') }}" novalidate>
-    {{ form.csrf_token }}
-    <fieldset>
-      <legend class="visually-hidden">{{ _("Rates Form") }}</legend>
-      {{ render_field(form.return_rate, class="form-control", placeholder=_("e.g., 7")) }}
-      {{ render_field(form.inflation_rate, class="form-control", placeholder=_("e.g., 2.5")) }}
+<div class="mb-12 max-w-3xl mx-auto">
+    <h2 class="text-center text-2xl md:text-3xl font-bold text-primary mb-2">{{ _("Calculation Wizard") }}</h2>
+    <p class="text-center text-secondary mb-6">{{ _("Follow the steps to get your FIRE projection.") }}</p>
+    <div class="w-full glassmorphic rounded-full h-2.5 p-0.5">
+        <div class="h-full rounded-full" style="width: 40%; background-color: var(--accent-color);"></div> {# Step 2 of 5 = 40% #}
+    </div>
+    <ol class="flex justify-between text-sm mt-2 px-1">
+        <li class="text-secondary">{{ _("Expenses") }}</li>
+        <li class="font-bold text-primary">{{ _("Rates") }}</li>
+        <li class="text-secondary">{{ _("One-Offs") }}</li>
+        <li class="text-secondary">{{ _("Results") }}</li>
+        <li class="text-secondary">{{ _("Summary") }}</li>
+    </ol>
+</div>
 
-      {{ render_field(form.total_duration_fallback, class="form-control", placeholder=_("e.g., 30")) }}
-      {{ render_field(form.desired_final_value, class="form-control", placeholder=_("e.g., 0")) }}
+<div class="glassmorphic p-6 md:p-10 rounded-2xl shadow-xl mx-auto max-w-3xl">
+    <h3 class="text-2xl md:text-3xl font-bold text-primary text-center mb-3">{{ title }}</h3>
+    <p class="text-secondary text-center mb-8">{{ _("Define your expected investment returns and inflation. You can also specify different return rates for distinct periods if needed.") }}</p>
+    <form method="POST" action="{{ url_for('wizard_bp.wizard_rates_step') }}" novalidate class="space-y-6">
+        {{ form.csrf_token }}
+        <fieldset>
+            <legend class="visually-hidden">{{ _("Rates Form") }}</legend>
 
-      <div class="mb-3">
-        {{ form.withdrawal_time.label(class="form-label") }}
-        {% for subfield in form.withdrawal_time %}
-          <div class="form-check">
-            {{ subfield(class="form-check-input") }}
-            {{ subfield.label(class="form-check-label") }}
-          </div>
-        {% endfor %}
-        {% if form.withdrawal_time.errors %}
-          <div class="invalid-feedback d-block">
-            {% for error in form.withdrawal_time.errors %}
-              <span>{{ error }}</span><br>
-            {% endfor %}
-          </div>
-        {% endif %}
-      </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+                {{ render_field(form.return_rate, placeholder=_("e.g., 7")) }}
+                {{ render_field(form.inflation_rate, placeholder=_("e.g., 2.5")) }}
+                {{ render_field(form.total_duration_fallback, placeholder=_("e.g., 30")) }}
+                {{ render_field(form.desired_final_value, placeholder=_("e.g., 0")) }}
+            </div>
 
-      <h4 class="mt-4">{{ _("Period-Specific Return Rates (Optional)") }}</h4>
-      <p><small>{{_("If you expect your investment return rate to change over time (e.g., lower returns in retirement), define those periods here. Otherwise, leave blank.")}}</small></p>
-      <div id="period-rates-list">
-        {% for period_form in form.period_rates %}
-          {{ render_field_list_item(period_form, loop.index0, 'period_rates', ['years', 'rate']) }}
-        {% endfor %}
-      </div>
-      {{ render_submit_field(form.submit_add_period, class="btn btn-secondary btn-sm mt-2", formnovalidate=True) }}
-    </fieldset>
-    {{ render_submit_field(form.submit, class="btn btn-primary mt-3") }}
-  </form>
+            <div class="mt-4"> {# Spacing for radio buttons #}
+                {{ form.withdrawal_time.label(class="text-sm font-medium text-secondary block mb-2") }}
+                <div class="flex space-x-4"> {# Horizontal layout for radio buttons #}
+                {% for subfield in form.withdrawal_time %}
+                  <div class="flex items-center">
+                    {{ subfield(class="themed-radio form-radio h-4 w-4 text-[var(--accent-color)] border-[var(--border-color)] focus:ring-[var(--accent-color)] mr-1.5") }}
+                    {{ subfield.label(class="text-sm text-secondary") }}
+                  </div>
+                {% endfor %}
+                </div>
+                {% if form.withdrawal_time.errors %}
+                  <div class="text-red-500 text-xs mt-1">
+                    {% for error in form.withdrawal_time.errors %}
+                      <span>{{ error }}</span><br>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+            </div>
+
+            <div class="pt-6 mt-6 border-t" style="border-color: rgba(var(--border-color), 0.2);">
+                <h4 class="text-xl font-semibold text-primary mb-1">{{ _("Period-Specific Return Rates (Optional)") }}</h4>
+                <p class="text-sm text-secondary mb-4">{{_("If you expect your investment return rate to change over time (e.g., lower returns in retirement), define those periods here. Otherwise, leave blank.")}}</p>
+                <div id="period-rates-list" class="space-y-3">
+                    {% for period_form in form.period_rates %}
+                      {{ render_field_list_item(period_form, loop.index0, 'period_rates', ['years', 'rate']) }}
+                    {% endfor %}
+                </div>
+                {{ render_submit_field(form.submit_add_period, class="btn-secondary text-sm py-1.5 px-4 rounded-md font-semibold mt-3", formnovalidate=True) }}
+            </div>
+        </fieldset>
+
+        <div class="flex justify-between items-center pt-6 mt-6 border-t" style="border-color: rgba(var(--border-color), 0.3);">
+            <a href="{{ url_for('wizard_bp.wizard_expenses_step') }}" class="btn-secondary py-2 px-5 rounded-md font-semibold text-base">{{ _("Previous") }}</a>
+            {{ render_submit_field(form.submit, class="btn-primary py-2 px-5 rounded-md font-semibold text-base") }}
+        </div>
+    </form>
+</div>
 {% endblock %}
 
 {% block scripts_extra %}

--- a/templates/wizard_results.html
+++ b/templates/wizard_results.html
@@ -7,142 +7,131 @@
 {% endblock %}
 
 {% block content %}
-  <h2>{{ title }}</h2>
+<div class="mb-12 max-w-3xl mx-auto">
+    <h2 class="text-center text-2xl md:text-3xl font-bold text-primary mb-2">{{ _("Calculation Wizard") }}</h2>
+    <p class="text-center text-secondary mb-6">{{ _("Follow the steps to get your FIRE projection.") }}</p>
+    <div class="w-full glassmorphic rounded-full h-2.5 p-0.5">
+        <div class="h-full rounded-full" style="width: 80%; background-color: var(--accent-color);"></div> {# Step 4 of 5 = 80% #}
+    </div>
+    <ol class="flex justify-between text-sm mt-2 px-1">
+        <li class="text-secondary">{{ _("Expenses") }}</li>
+        <li class="text-secondary">{{ _("Rates") }}</li>
+        <li class="text-secondary">{{ _("One-Offs") }}</li>
+        <li class="font-bold text-primary">{{ _("Results") }}</li>
+        <li class="text-secondary">{{ _("Summary") }}</li>
+    </ol>
+</div>
+
+<header class="text-center mb-12">
+    <h1 class="text-4xl md:text-5xl font-extrabold text-primary tracking-tight">{{ title }}</h1>
+    <p class="mt-4 max-w-2xl mx-auto text-lg text-secondary">{{ _("You've completed the wizard. Explore your path to financial independence below.") }}</p>
+</header>
 
   {# Display general error message if any from initial calculation #}
   {% if error_message %}
-    <div class="alert alert-danger" role="alert">
-      <h4>{{_("Initial Calculation Error")}}</h4>
-      <p>{{ error_message }}</p>
+    <div class="alert alert-danger max-w-3xl mx-auto glassmorphic p-4 mb-8" role="alert">
+      <h4 class="text-xl font-bold text-red-700">{{_("Initial Calculation Error")}}</h4>
+      <p class="text-red-600">{{ error_message }}</p>
     </div>
   {% endif %}
 
   {# --- Main Key Results & Consolidated Fixed Inputs --- #}
-  <div class="card text-center mb-4">
-    <div class="card-header">
-      {{_("Calculation Summary")}}
+<section id="key-metrics" class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 mb-12 max-w-5xl mx-auto">
+    <div class="glassmorphic rounded-2xl p-6 text-center">
+        <h3 class="text-lg font-semibold text-secondary">{{_("Your FIRE Number")}}</h3>
+        <p id="display_p_metric" class="text-4xl md:text-5xl font-bold mt-2" style="color: var(--accent-color);">{{ P_calculated_display if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" else "N/A" }}</p>
     </div>
-    <div class="card-body">
-      {% if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" %}
-        <h3 class="card-title">{{_("Your Calculated FIRE Number:")}}</h3>
-        <p id="display_p" class="display-4 fw-bold text-success">{{ P_calculated_display }}</p> {# Static Original P #}
-        <hr>
-        <h5 class="card-title mt-3">{{_("Based on:")}}</h5>
-        <p id="display_w" class="card-text fs-5 mb-1"> {# Static Original W #}
-          {{_("Input Annual Expenses (W):")}} <strong>{{ W_display }}</strong>
-        </p>
-      {% elif P_calculated_display %}
-        <div class="alert alert-warning" role="alert">
-            <h4 class="alert-heading">{{_("Calculation Outcome")}}</h4>
-            <p class="fs-5">{{_("Calculated Required Initial Portfolio (FIRE Number):")}} <strong id="display_p">{{ P_calculated_display }}</strong></p>
-            <hr>
-            <p class="mb-0">{{_("Based on Input Annual Expenses (W):")}} <strong id="display_w">{{ W_display | default(W) }}</strong></p>
-        </div>
-      {% endif %}
-      <div class="mt-3 text-muted small">
-        <p class="mb-1">
-          {{_("Overall Nominal Return:")}} {{ (r_overall_nominal * 100) | round(2) }}% |
-          {{_("Inflation:")}} {{ (i_overall * 100) | round(2) }}% |
-          {{_("Duration:")}} {{ total_duration_from_periods }} {{_("yrs")}}
-        </p>
-        <p class="mb-1">
-          {{_("Withdrawal Timing:")}} {{ withdrawal_time_str | capitalize }} |
-          {{_("Desired Final Portfolio:")}} {{ desired_final_value | default(0.0) }}
-        </p>
-        {% if rates_periods_summary and (rates_periods_summary | length > 1 or (rates_periods_summary | length == 1 and (rates_periods_summary[0].r != r_overall_nominal or rates_periods_summary[0].i != i_overall))) %}
-          <p class="mb-1"><em>{{_("Custom rate periods applied for specific durations.")}}</em></p>
-        {% endif %}
-        {% if one_off_events_summary %}
-          <p class="mb-0"><em>{{_("One-off financial events considered.")}}</em></p>
-        {% else %}
-          <p class="mb-0"><em>{{_("No one-off events specified.")}}</em></p>
-        {% endif %}
-      </div>
+    <div class="glassmorphic rounded-2xl p-6 text-center">
+        <h3 class="text-lg font-semibold text-secondary">{{_("Input Annual Expenses (W)")}}</h3>
+        <p id="display_w_metric" class="text-4xl md:text-5xl font-bold text-primary mt-2">{{ W_display | default(W) if W_display or W else "N/A" }}</p>
     </div>
-  </div>
+    <div class="glassmorphic rounded-2xl p-6 text-center">
+        <h3 class="text-lg font-semibold text-secondary">{{_("Total Duration")}}</h3>
+        <p class="text-4xl md:text-5xl font-bold text-primary mt-2">{{ total_duration_from_periods }} {{_("yrs")}}</p>
+    </div>
+</section>
+
+{# Optional smaller card for detailed parameters summary #}
+<div class="glassmorphic rounded-xl p-4 mb-12 max-w-3xl mx-auto text-sm text-secondary text-center">
+    <p class="mb-1">
+      {{_("Overall Nominal Return:")}} {{ (r_overall_nominal * 100) | round(2) }}% |
+      {{_("Inflation:")}} {{ (i_overall * 100) | round(2) }}% |
+      {{_("Withdrawal Timing:")}} {{ withdrawal_time_str | capitalize }} |
+      {{_("Desired Final Portfolio:")}} {{ desired_final_value | default(0.0) }}
+    </p>
+    {% if rates_periods_summary and (rates_periods_summary | length > 1 or (rates_periods_summary | length == 1 and (rates_periods_summary[0].r != r_overall_nominal or rates_periods_summary[0].i != i_overall))) %}
+      <p class="mb-1"><em>{{_("Custom rate periods applied for specific durations.")}}</em></p>
+    {% endif %}
+    {% if one_off_events_summary %}
+      <p class="mb-0"><em>{{_("One-off financial events considered.")}}</em></p>
+    {% else %}
+      <p class="mb-0"><em>{{_("No one-off events specified.")}}</em></p>
+    {% endif %}
+</div>
 
   {# --- Static Original Calculation Plots (Side-by-Side) --- #}
-  <h3 class="mt-4 mb-3 text-center">{{_("Original Calculation Plots")}}</h3>
+  <h3 class="text-2xl font-bold text-primary mb-6 text-center mt-12">{{_("Original Calculation Plots")}}</h3>
   {% if P_calculated_display and P_calculated_display != "Error" and P_calculated_display != "Not Feasible" %}
-    <div class="row mb-4"> {# Row for the pair of original plot panels #}
-      <div class="col-md-6">
-        <div class="card">
-          <div class="card-body">
-            <h5 class="card-title text-center">{{_("Original Portfolio Balance")}}</h5>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mb-12">
+        <div class="glassmorphic rounded-2xl p-6 md:p-8">
+            <h4 class="text-xl font-semibold text-primary mb-4 text-center">{{_("Original Portfolio Balance")}}</h4>
             <div id="original_plot1_container" style="min-height: 350px;"></div>
-          </div>
         </div>
-      </div>
-      <div class="col-md-6">
-        <div class="card">
-          <div class="card-body">
-            <h5 class="card-title text-center">{{_("Original Annual Withdrawals")}}</h5>
+        <div class="glassmorphic rounded-2xl p-6 md:p-8">
+            <h4 class="text-xl font-semibold text-primary mb-4 text-center">{{_("Original Annual Withdrawals")}}</h4>
             <div id="original_plot2_container" style="min-height: 350px;"></div>
-          </div>
         </div>
-      </div>
     </div>
   {% else %}
-    <p class="text-center">{{_("Original plots not available due to calculation error or infeasible scenario.")}}</p>
+    <p class="text-center text-secondary">{{_("Original plots not available due to calculation error or infeasible scenario.")}}</p>
   {% endif %}
 
   {# --- Interactive What-If Analysis (Card with Sliders and its own Plots) --- #}
-  <div class="card text-center mb-4 mt-5">
-    <div class="card-header">
-      {{_("Interactive What-If Analysis")}}
-    </div>
+  <section id="interactive-analysis" class="glassmorphic rounded-2xl p-6 md:p-8 mb-12 mt-12">
+    <h3 class="text-2xl font-bold text-primary mb-2 text-center">{{_("Interactive What-If Analysis")}}</h3>
     <div class="card-body">
-      <p class="text-muted small mb-3">
+      <p class="text-secondary text-center mb-6 text-sm">
         {{_("Adjust the 'Annual Expenses' or 'Target Portfolio' values below using the input fields or sliders. The other value and the plots in this section will update automatically to reflect your changes. All other parameters (rates, duration, etc.) remain fixed based on your initial wizard inputs.")}}
       </p>
       {# Row for W input and slider #}
-      <div class="row g-3 align-items-center justify-content-center mb-3">
+      <div class="row align-items-center justify-content-center mb-3">
         <div class="col-md-3 text-md-end">
-          <label for="interactive_w" class="col-form-label">{{_("Adjust Annual Expenses (W):")}}</label>
+          <label for="interactive_w" class="text-sm font-medium text-secondary whitespace-nowrap">{{_("Adjust Annual Expenses (W):")}}</label>
         </div>
         <div class="col-md-3">
-          <input type="number" id="interactive_w" class="form-control interactive-input" data-changed="W" value="{{ W | default(0.0) }}" step="1000" min="0">
+          <input type="number" id="interactive_w" class="themed-input interactive-input" data-changed="W" value="{{ W | default(0.0) }}" step="1000" min="0">
         </div>
         <div class="col-md-6">
-          <input type="range" id="slider_w" class="form-range interactive-slider" data-target="interactive_w" value="{{ W | default(0.0) }}" min="0" max="{{ (W * 2) | default(100000) | int }}" step="1000">
+          <input type="range" id="slider_w" class="themed-range interactive-slider" data-target="interactive_w" value="{{ W | default(0.0) }}" min="0" max="{{ (W * 2) | default(100000) | int }}" step="1000">
         </div>
       </div>
 
       {# Row for P input and slider #}
-      <div class="row g-3 align-items-center justify-content-center mb-3">
+      <div class="row align-items-center justify-content-center mb-3">
         <div class="col-md-3 text-md-end">
-          <label for="interactive_p" class="col-form-label">{{_("Adjust Target Portfolio (P):")}}</label>
+          <label for="interactive_p" class="text-sm font-medium text-secondary whitespace-nowrap">{{_("Adjust Target Portfolio (P):")}}</label>
         </div>
         <div class="col-md-3">
-          <input type="number" id="interactive_p" class="form-control interactive-input" data-changed="P" value="{{ P_raw | default(0.0) }}" step="10000" min="0">
+          <input type="number" id="interactive_p" class="themed-input interactive-input" data-changed="P" value="{{ P_raw | default(0.0) }}" step="10000" min="0">
         </div>
         <div class="col-md-6">
-          <input type="range" id="slider_p" class="form-range interactive-slider" data-target="interactive_p" value="{{ P_raw | default(0.0) }}" min="0" max="{{ (P_raw * 2) | default(2000000) | int }}" step="10000">
+          <input type="range" id="slider_p" class="themed-range interactive-slider" data-target="interactive_p" value="{{ P_raw | default(0.0) }}" min="0" max="{{ (P_raw * 2) | default(2000000) | int }}" step="10000">
         </div>
       </div>
-      {# The old <small> text was here, now removed. #}
 
       {# New Plot Containers for Interactive Analysis (Side-by-Side) #}
-      <div class="row mt-4"> {# Row for the pair of interactive plot panels #}
-        <div class="col-md-6">
-          <div class="card">
-            <div class="card-body">
-              <h5 class="card-title text-center">{{_("Interactive Portfolio Balance")}}</h5>
-              <div id="interactive_plot1_container" style="min-height: 350px;"></div>
-            </div>
-          </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mt-8">
+        <div class="glassmorphic rounded-xl p-4">
+            <h4 class="text-lg font-semibold text-primary mb-3 text-center">{{_("Interactive Portfolio Balance")}}</h4>
+            <div id="interactive_plot1_container" style="min-height: 350px;"></div>
         </div>
-        <div class="col-md-6">
-          <div class="card">
-            <div class="card-body">
-              <h5 class="card-title text-center">{{_("Interactive Annual Withdrawals")}}</h5>
-              <div id="interactive_plot2_container" style="min-height: 350px;"></div>
-            </div>
-          </div>
+        <div class="glassmorphic rounded-xl p-4">
+            <h4 class="text-lg font-semibold text-primary mb-3 text-center">{{_("Interactive Annual Withdrawals")}}</h4>
+            <div id="interactive_plot2_container" style="min-height: 350px;"></div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
   {# Hidden fields/script tags for fixed parameters #}
   <input type="hidden" id="initial_r_overall_nominal" value="{{ r_overall_nominal | default(0.0) }}">
@@ -155,10 +144,11 @@
   <script id="original-plot1-spec-data" type="application/json">{{ original_plot1_spec | default({}) | tojson | safe }}</script>
   <script id="original-plot2-spec-data" type="application/json">{{ original_plot2_spec | default({}) | tojson | safe }}</script>
 
-  <div class="mt-4 text-center">
-    <a href="{{ url_for('wizard_bp.wizard_expenses_step') }}" class="btn btn-secondary">{{ _("Start New Wizard") }}</a>
-    <a href="{{ url_for('wizard_bp.export_csv') }}" class="btn btn-success">{{ _("Export Results to CSV") }}</a>
-    <a href="{{ url_for('wizard_bp.export_pdf') }}" class="btn btn-danger">{{ _("Export Results to PDF") }}</a>
+  <section class="text-center mt-12">
+    <div class="flex flex-wrap justify-center gap-4">
+    <a href="{{ url_for('wizard_bp.wizard_expenses_step') }}" class="btn-secondary py-2 px-5 rounded-md font-semibold text-base">{{ _("Start New Wizard") }}</a>
+    <a href="{{ url_for('wizard_bp.export_csv') }}" class="btn-primary py-2 px-5 rounded-md font-semibold text-base">{{ _("Export Results to CSV") }}</a>
+    <a href="{{ url_for('wizard_bp.export_pdf') }}" class="btn-primary py-2 px-5 rounded-md font-semibold text-base">{{ _("Export Results to PDF") }}</a>
 
     {% if W is not none %} {# Only show if there was a successful calculation and W is available #}
       {% set query_params = {
@@ -198,10 +188,11 @@
           {% endif %}
         {% endfor %}
       {% endif %}
-      <a href="{{ url_for('project.compare', **query_params) }}" class="btn btn-info">{{ _("Compare These Results") }}</a>
+      <a href="{{ url_for('project.compare', **query_params) }}" class="btn-secondary py-2 px-5 rounded-md font-semibold text-base">{{ _("Compare These Results") }}</a>
     {% endif %}
-    <a href="{{ url_for('project.index') }}" class="btn btn-info">{{ _("Back to Home") }}</a>
-  </div>
+    <a href="{{ url_for('project.index') }}" class="btn-secondary py-2 px-5 rounded-md font-semibold text-base">{{ _("Back to Home") }}</a>
+    </div>
+  </section>
 
 {% endblock %}
 

--- a/templates/wizard_summary.html
+++ b/templates/wizard_summary.html
@@ -3,89 +3,101 @@
 {% block title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block content %}
-  <h2>{{ title }}</h2>
-  <p>{{ _("Please review the information you've provided. If everything is correct, you can proceed to calculate your FIRE projection.") }}</p>
-
-  <div class="card mb-3">
-    <div class="card-header">
-      <h4>{{ _("Expenses Summary") }}</h4>
+<div class="mb-12 max-w-3xl mx-auto">
+    <h2 class="text-center text-2xl md:text-3xl font-bold text-primary mb-2">{{ _("Calculation Wizard") }}</h2>
+    <p class="text-center text-secondary mb-6">{{ _("Follow the steps to get your FIRE projection.") }}</p>
+    <div class="w-full glassmorphic rounded-full h-2.5 p-0.5">
+        <div class="h-full rounded-full" style="width: 100%; background-color: var(--accent-color);"></div> {# Step 5 of 5 = 100% #}
     </div>
-    <ul class="list-group list-group-flush">
-      <li class="list-group-item"><strong>{{ _("Total Annual Expenses:") }}</strong> {{ expenses_data.annual_expenses | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Housing:") }}</strong> {{ expenses_data.housing | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Food:") }}</strong> {{ expenses_data.food | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Transportation:") }}</strong> {{ expenses_data.transportation | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Utilities:") }}</strong> {{ expenses_data.utilities | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Personal Care:") }}</strong> {{ expenses_data.personal_care | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Entertainment:") }}</strong> {{ expenses_data.entertainment | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Healthcare:") }}</strong> {{ expenses_data.healthcare | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Other Expenses:") }}</strong> {{ expenses_data.other_expenses | default(_('N/A')) }}</li>
-    </ul>
-  </div>
+    <ol class="flex justify-between text-sm mt-2 px-1">
+        <li class="text-secondary">{{ _("Expenses") }}</li>
+        <li class="text-secondary">{{ _("Rates") }}</li>
+        <li class="text-secondary">{{ _("One-Offs") }}</li>
+        <li class="text-secondary">{{ _("Results") }}</li>
+        <li class="font-bold text-primary">{{ _("Summary") }}</li>
+    </ol>
+</div>
 
-  <div class="card mb-3">
-    <div class="card-header">
-      <h4>{{ _("Rates Summary") }}</h4>
-    </div>
-    <ul class="list-group list-group-flush">
-      <li class="list-group-item"><strong>{{ _("Overall Portfolio Return Rate (%%):") }}</strong> {{ rates_data.return_rate | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Assumed Annual Inflation Rate (%%):") }}</strong> {{ rates_data.inflation_rate | default(_('N/A')) }}</li>
-      <li class="list-group-item"><strong>{{ _("Total Duration (Fallback, if no periods):") }}</strong> {{ rates_data.total_duration_fallback | default(30) }} {{ _("years") }}</li>
-      <li class="list-group-item"><strong>{{ _("Desired Final Portfolio Value:") }}</strong> {{ rates_data.desired_final_value | default(0.0) }}</li>
-      <li class="list-group-item"><strong>{{ _("Withdrawal Timing:") }}</strong> {{ rates_data.withdrawal_time | capitalize | default(_('End of Year')) }}</li>
-      {% if rates_data.period_rates %}
-        <li class="list-group-item"><strong>{{ _("Period-Specific Return Rates:") }}</strong></li>
-        {% for period in rates_data.period_rates %}
-          {% if period.years and period.rate is not none %} {# Check if period has data #}
-            <li class="list-group-item ms-3">&bull; {{ _("Years:") }} {{ period.years }}, {{ _("Rate:") }} {{ period.rate }}%</li>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-    </ul>
-  </div>
+<div class="glassmorphic p-6 md:p-10 rounded-2xl shadow-xl mx-auto max-w-4xl space-y-8">
+    <h2 class="text-3xl font-bold text-primary text-center mb-2">{{ title }}</h2>
+    <p class="text-secondary text-center mb-6">{{ _("Please review the information you've provided. If everything is correct, you can proceed to calculate your FIRE projection.") }}</p>
 
-  <div class="card mb-3">
-    <div class="card-header">
-      <h4>{{ _("One-Off Events Summary") }}</h4>
-    </div>
-    {% if one_offs_data.large_expenses %}
-      <div class="card-body">
-        <h5>{{ _("Large One-Off Expenses:") }}</h5>
-        <ul class="list-group">
-          {% for expense in one_offs_data.large_expenses %}
-            {% if expense.year is not none and expense.amount is not none %} {# Check if expense has data #}
-              <li class="list-group-item">{{ _("Year:") }} {{ expense.year }}, {{ _("Amount:") }} {{ expense.amount }}{% if expense.description %}, {{ _("Desc:") }} {{ expense.description }}{% endif %}</li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
-    {% if one_offs_data.large_incomes %}
-      <div class="card-body">
-        <h5>{{ _("Large One-Off Incomes:") }}</h5>
-        <ul class="list-group">
-          {% for income in one_offs_data.large_incomes %}
-            {% if income.year is not none and income.amount is not none %} {# Check if income has data #}
-              <li class="list-group-item">{{ _("Year:") }} {{ income.year }}, {{ _("Amount:") }} {{ income.amount }}{% if income.description %}, {{ _("Desc:") }} {{ income.description }}{% endif %}</li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
-    {% if not one_offs_data.large_expenses and not one_offs_data.large_incomes %}
-        <div class="card-body">
-            <p>{{_("No one-off events were specified.")}}</p>
+    <section class="pb-6 border-b border-[rgba(var(--border-color),0.2)]">
+        <h3 class="text-xl font-semibold text-primary mb-4">{{ _("Expenses Summary") }}</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-3 text-sm">
+            <div><span class="text-secondary">{{ _("Total Annual Expenses:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.annual_expenses | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Housing:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.housing | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Food:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.food | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Transportation:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.transportation | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Utilities:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.utilities | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Personal Care:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.personal_care | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Entertainment:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.entertainment | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Healthcare:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.healthcare | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Other Expenses:") }}</span> <strong class="text-primary block sm:inline">{{ expenses_data.other_expenses | default(_('N/A')) }}</strong></div>
         </div>
-    {% endif %}
-  </div>
+    </section>
 
-  <div class="mt-4">
-    <a href="{{ url_for('wizard_bp.wizard_one_offs_step') }}" class="btn btn-secondary">{{ _("Back to One-Offs") }}</a>
-    {# TODO: Add a button/link to "Edit" previous steps #}
-    <form method="POST" action="{{ url_for('wizard_bp.wizard_calculate_step') }}" class="d-inline ms-2">
+    <section class="pb-6 border-b border-[rgba(var(--border-color),0.2)]">
+        <h3 class="text-xl font-semibold text-primary mb-4">{{ _("Rates Summary") }}</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+            <div><span class="text-secondary">{{ _("Overall Portfolio Return Rate (%%):") }}</span> <strong class="text-primary block sm:inline">{{ rates_data.return_rate | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Assumed Annual Inflation Rate (%%):") }}</span> <strong class="text-primary block sm:inline">{{ rates_data.inflation_rate | default(_('N/A')) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Total Duration (Fallback, if no periods):") }}</span> <strong class="text-primary block sm:inline">{{ rates_data.total_duration_fallback | default(30) }} {{ _("years") }}</strong></div>
+            <div><span class="text-secondary">{{ _("Desired Final Portfolio Value:") }}</span> <strong class="text-primary block sm:inline">{{ rates_data.desired_final_value | default(0.0) }}</strong></div>
+            <div><span class="text-secondary">{{ _("Withdrawal Timing:") }}</span> <strong class="text-primary block sm:inline">{{ rates_data.withdrawal_time | capitalize | default(_('End of Year')) }}</strong></div>
+        </div>
+        {% if rates_data.period_rates and rates_data.period_rates | selectattr('years') | list | length > 0 %}
+            <div class="mt-3">
+                <h4 class="text-md font-semibold text-primary mb-1">{{ _("Period-Specific Return Rates:") }}</h4>
+                <ul class="list-disc list-inside text-sm space-y-1 pl-1">
+                {% for period in rates_data.period_rates %}
+                  {% if period.years and period.rate is not none %}
+                    <li><span class="text-secondary">{{ _("Years:") }} {{ period.years }}, {{ _("Rate:") }} {{ period.rate }}%</span></li>
+                  {% endif %}
+                {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+    </section>
+
+    <section class="pb-6 border-b border-[rgba(var(--border-color),0.2)] last:border-b-0 last:pb-0">
+        <h3 class="text-xl font-semibold text-primary mb-4">{{ _("One-Off Events Summary") }}</h3>
+        {% if one_offs_data.large_expenses and one_offs_data.large_expenses | selectattr('year') | list | length > 0 %}
+          <div class="mb-3">
+            <h4 class="text-md font-semibold text-primary mb-1">{{ _("Large One-Off Expenses:") }}</h4>
+            <ul class="list-disc list-inside text-sm space-y-1 pl-1">
+            {% for expense in one_offs_data.large_expenses %}
+              {% if expense.year is not none and expense.amount is not none %}
+                <li><span class="text-secondary">{{ _("Year:") }} {{ expense.year }}, {{ _("Amount:") }} {{ expense.amount }}{% if expense.description %}, {{ _("Desc:") }} {{ expense.description }}{% endif %}</span></li>
+              {% endif %}
+            {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+        {% if one_offs_data.large_incomes and one_offs_data.large_incomes | selectattr('year') | list | length > 0 %}
+          <div class="mb-3">
+            <h4 class="text-md font-semibold text-primary mb-1">{{ _("Large One-Off Incomes:") }}</h4>
+            <ul class="list-disc list-inside text-sm space-y-1 pl-1">
+            {% for income in one_offs_data.large_incomes %}
+              {% if income.year is not none and income.amount is not none %}
+                <li><span class="text-secondary">{{ _("Year:") }} {{ income.year }}, {{ _("Amount:") }} {{ income.amount }}{% if income.description %}, {{ _("Desc:") }} {{ income.description }}{% endif %}</span></li>
+              {% endif %}
+            {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+        {% if not (one_offs_data.large_expenses and one_offs_data.large_expenses | selectattr('year') | list | length > 0) and not (one_offs_data.large_incomes and one_offs_data.large_incomes | selectattr('year') | list | length > 0) %}
+            <p class="text-sm text-secondary">{{_("No one-off events were specified.")}}</p>
+        {% endif %}
+    </section>
+</div>
+
+<div class="flex justify-between items-center pt-8 mt-8 border-t border-[rgba(var(--border-color),0.3)] max-w-4xl mx-auto">
+    <a href="{{ url_for('wizard_bp.wizard_one_offs_step') }}" class="btn-secondary py-2 px-5 rounded-md font-semibold text-base">{{ _("Back to One-Offs") }}</a>
+    <form method="POST" action="{{ url_for('wizard_bp.wizard_calculate_step') }}" class="inline">
       <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
-      <button type="submit" class="btn btn-primary">{{ _("Calculate with this Data") }}</button>
+      <button type="submit" class="btn-primary py-2 px-5 rounded-md font-semibold text-base">{{ _("Calculate with this Data") }}</button>
     </form>
-    <p class="mt-2"><small>{{_("Note: Calculation will use the data summarized above and will clear the wizard session.")}}</small></p>
-  </div>
+</div>
+<p class="mt-4 text-sm text-secondary text-center max-w-4xl mx-auto">{{_("Note: Calculation will use the data summarized above and will clear the wizard session.")}}</p>
 {% endblock %}


### PR DESCRIPTION
This commit continues the UI revamp, focusing on applying the new visual theme to all wizard pages and the 'about.html' static page.

Key changes:

- **Themed Form Elements (CSS & Helpers):**
  - Added CSS to `static/css/main.css` for `.themed-input`, `.themed-select`, `.themed-radio`, `.themed-checkbox`, `.themed-range`, and table elements to ensure consistent styling.
  - Updated `templates/_formhelpers.html` macros to use these new classes, enabling automatic styling for WTForms-generated fields.
  - Defined a `.btn-secondary` style for secondary actions.

- **Wizard Pages Restyled (`wizard_expenses.html`, `wizard_rates.html`, `wizard_one_offs.html`, `wizard_results.html`, `wizard_summary.html`):**
  - Each wizard step now includes a visual progress bar.
  - Main content of each step is wrapped in a `glassmorphic` container.
  - Typography (titles, paragraphs) updated to match the new theme.
  - All form elements (inputs, selects, radio buttons, checkboxes, sliders) are styled using the new themed classes.
  - Layout of form fields and summary data presentation modernized (e.g., using grids, cleaner lists).
  - Navigation buttons ("Previous", "Next", "Add Item") consistently styled.
  - `wizard_results.html` received a significant layout overhaul for key metrics, plots, and interactive analysis sections.

- **Static Page Restyled (`about.html`):**
  - `about.html` updated with a `glassmorphic` container, new typography, and themed list styles.

The wizard flow and the 'About' page now fully reflect the new UI design, providing a consistent user experience. The landing page (`index.html`) currently serves as an entry point to the wizard, styled with the new theme's aesthetics but not mirroring the specific layout of `ref_index.html` (which is more of a compare/dashboard layout).