### PR TITLE
fix: Escape percentage signs in translatable strings

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,7 @@
             <hr class="hr-themed">
             <div class="text-secondary space-y-2">
                 <p class="flex justify-between"><span>{{ _("Monthly Contribution:") }}</span><span class="font-medium text-primary">{{ _("$1,500") }}</span></p>
-                <p class="flex justify-between"><span>{{ _("Annual Return:") }}</span><span class="font-medium text-primary">{{ _("7%") }}</span></p>
+                <p class="flex justify-between"><span>{{ _("Annual Return:") }}</span><span class="font-medium text-primary">{{ _("7%%") }}</span></p>
                 <p class="flex justify-between"><span>{{ _("Retirement Spending:") }}</span><span class="font-medium text-primary">{{ _("$50,000 / year") }}</span></p>
             </div>
             <div class="pt-4">
@@ -66,7 +66,7 @@
             <hr class="hr-themed">
             <div class="text-secondary space-y-2">
                 <p class="flex justify-between"><span>{{ _("Monthly Contribution:") }}</span><span class="font-medium text-primary">{{ _("$1,800") }}</span></p>
-                <p class="flex justify-between"><span>{{ _("Annual Return:") }}</span><span class="font-medium text-primary">{{ _("7%") }}</span></p>
+                <p class="flex justify-between"><span>{{ _("Annual Return:") }}</span><span class="font-medium text-primary">{{ _("7%%") }}</span></p>
                 <p class="flex justify-between"><span>{{ _("Retirement Spending:") }}</span><span class="font-medium text-primary">{{ _("$45,000 / year") }}</span></p>
             </div>
             <div class="pt-4">


### PR DESCRIPTION
Corrects a `ValueError: incomplete format` that occurred during Jinja2 template rendering for `templates/index.html`.

The error was caused by unescaped '%' characters in strings like "7%" being passed to the `_()` gettext function, which misinterpreted them as string formatting placeholders.

This commit fixes the issue by changing `_("7%")` to `_("7%%")` in the affected lines, ensuring the percentage sign is treated as a literal character.