### PR TITLE
fix: Refactor 'Informative Guides' panel for robust i18n

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,11 @@
     <div class="glassmorphic rounded-2xl p-6 md:p-8">
         <h2 class="text-2xl font-bold text-primary mb-4">{{ _("Informative Guides") }}</h2>
         <p class="text-secondary">
-            {{ _("Access our <a href=\"%s\" class=\"%s\">FAQ</a> and <a href=\"%s\" class=\"%s\">About</a> sections to learn more about the FIRE movement.")|safe|format(url_for('project.faq'), 'text-accent-color hover:underline', url_for('project.about'), 'text-accent-color hover:underline') }}
+            {{ _("Access our") }}
+            <a href="{{ url_for('project.faq') }}" class="text-accent-color hover:underline">{{ _("FAQ") }}</a>
+            {{ _("and") }}
+            <a href="{{ url_for('project.about') }}" class="text-accent-color hover:underline">{{ _("About") }}</a>
+            {{ _("sections to learn more about the FIRE movement.") }}
         </p>
     </div>
 </div>


### PR DESCRIPTION
Corrects a `TypeError: not enough arguments for format string` in the 'Informative Guides' panel on `templates/index.html`.

The error was caused by the interaction of complex HTML and `%s` placeholders within a single `_()` gettext call combined with Jinja's `format` filter.

This commit refactors the panel by:
- Separating translatable text segments from HTML link construction.
- Using standard Jinja `url_for` for link `href` attributes.
- Applying `_()` only to individual, simple text strings.

This approach resolves the error and makes the section more robust and easier to translate accurately.