### PR TITLE
Fix: Ensure compare scenario panels are always stacked vertically

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -759,25 +759,20 @@ input[type="submit"]:hover {
   margin-right: 10px;
 }
 .scenario-container {
-  display: flex;
-  flex-wrap: nowrap; /* Allows horizontal scrolling if too many scenarios */
-  gap: 10px;
-  margin-bottom: 20px;
-  overflow-x: auto; /* Enable horizontal scroll for scenarios */
+  /* display: flex; /* Overridden by Tailwind 'grid' */
+  /* flex-wrap: nowrap; /* Not relevant for grid / vertical stack */
+  /* gap: 10px; /* Replaced by Tailwind 'gap-y-8' in HTML */
+  /* margin-bottom: 20px; /* Handled by Tailwind on form or other elements */
+  /* overflow-x: auto; /* Not needed for vertical stack */
 }
 .scenario {
-  flex: 1 0 200px; /* Flex basis of 200px, can grow and shrink */
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  padding: 10px;
-  background: #fff; /* Scenarios have their own background */
-  min-width: 200px; /* Min width for a scenario box */
-  cursor: move;
+  /* flex: 1 0 200px; /* Not relevant for grid items in a single column */
+  /* border, padding, background, radius are handled by Tailwind & glassmorphic classes */
+  min-width: 200px; /* Retain min-width if desired, though grid items stretch */
+  cursor: move; /* For sortable functionality */
 }
-[data-bs-theme="dark"] .scenario { /* This specific .scenario might be a .card now */
-    background: #3a3a3a;
-    border-color: #555;
-}
+/* [data-bs-theme="dark"] .scenario styling is overridden by glassmorphic */
+
 /*
 .scenario h3 {
   margin-top: 0;

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -32,7 +32,7 @@
 </div>
 
   <form method="post" action="{{ url_for('project.compare') }}" id="compareForm" class="space-y-8">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8 scenario-container">
+    <div class="grid grid-cols-1 gap-y-8 scenario-container"> {# Removed md:grid-cols-2 and gap-x-8 for full vertical layout #}
       {# The scenarios variable is passed from the route #}
       {% for scenario in scenarios %}
       <div class="scenario glassmorphic rounded-2xl p-6 md:p-8 flex flex-col space-y-6" id="scenario{{scenario.n}}"{% if not scenario.enabled %}style="display:none;"{% endif %}>


### PR DESCRIPTION
This commit addresses your feedback regarding overlapping compare scenario panels. The scenario panels themselves are now always stacked one below the other, regardless of screen size, to prevent any horizontal overlap.

Key changes:
- Modified `templates/compare.html`:
    - Changed `div.scenario-container` classes from `grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8` to `grid grid-cols-1 gap-y-8`. This enforces a single-column layout for scenario panels across all screen sizes.
- Adjusted `static/css/main.css`:
    - Commented out older, conflicting custom CSS rules for `.scenario-container` (e.g., `display: flex`) and `.scenario` (e.g., `flex` properties) to allow Tailwind utility classes to control the layout effectively.

This ensures that each scenario comparison panel takes the full width and stacks vertically, providing a more robust and clearer layout, especially when multiple scenarios are active.