### PR TITLE
Fix: Resolve UndefinedError for 'scenario_data' in compare.html scrip…

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -370,7 +370,7 @@
               // Update individual scenario results (e.g., FIRE number or error within each card)
               response.scenarios.forEach(function(sc, index) {
                   // Assumes cards will be dynamically ID'd like "scenario1", "scenario2" etc.
-                  // The Jinja loop now creates "scenario{{ scenario_data.n }}"
+                  // The Jinja loop in the content block creates scenario cards with IDs like "scenarioX" (e.g., scenario1, scenario2)
                   var scenarioCard = $("#scenario" + sc.n);
                   if (scenarioCard.length === 0) {
                       console.warn('[CompareDebug] Scenario card div not found for scenario number:', sc.n);


### PR DESCRIPTION
…t block

A `jinja2.exceptions.UndefinedError: 'scenario_data' is undefined` was occurring during the rendering of `templates/compare.html`. This was caused by an erroneous Jinja2 interpolation `{{ scenario_data.n }}` within a JavaScript comment in the `{% block scripts_extra %}`.

The `scenario_data` variable is defined within a for-loop in the `{% block content %}` and is not in scope in the `{% block scripts_extra %}`.

This commit corrects the comment to remove the Jinja2 interpolation, resolving the template rendering error. The comment now generically refers to how scenario IDs are created.