### PR TITLE
Fix: Resolve HTTP 400 Bad Request on POST /compare

### DIFF
--- a/project/routes.py
+++ b/project/routes.py
@@ -389,7 +389,14 @@ def compare():
                             scenario_rates_periods.append({'duration': duration, 'r': r_perc / 100, 'i': i_perc / 100})
                         elif duration < 0: raise ValueError(gettext("Period %(p_num)s duration cannot be negative.", p_num=p_num))
                 if not scenario_rates_periods:
-                    r_perc_single, i_perc_single, T_single = float(scenario_input['r_form']), float(scenario_input['i_form']), int(scenario_input['T_form'])
+                    r_form_str = scenario_input.get('r_form')
+                    i_form_str = scenario_input.get('i_form')
+                    T_form_str = scenario_input.get('T_form')
+
+                    r_perc_single = float(r_form_str) if r_form_str else 0.0
+                    i_perc_single = float(i_form_str) if i_form_str else 0.0
+                    T_single = int(T_form_str) if T_form_str else 0
+
                     if T_single <= 0: raise ValueError(gettext("Time (T) must be > 0 for single period mode."))
                     if not (-50 <= r_perc_single <= 100): raise ValueError(gettext("Annual return (r) must be between -50% and 100%."))
                     if not (-50 <= i_perc_single <= 100): raise ValueError(gettext("Inflation rate (i) must be between -50% and 100%."))


### PR DESCRIPTION
An HTTP 400 Bad Request was occurring when submitting the compare scenarios form if an 'enabled' scenario had no periodic rates defined and also had empty strings for its fallback Overall Return (R), Overall Inflation (I), or Total Duration (T) input fields.

This was because the backend was attempting to directly convert these empty strings to float/int, raising a ValueError that, despite being within a try-except block for individual scenario processing, appeared to escalate to a global 400 error.

This commit modifies the `compare()` function in `project/routes.py`:
- When parsing fallback R, I, T values for an enabled scenario:
    - Input strings are now retrieved first.
    - If an input string is empty, it's defaulted to 0.0 (for R, I) or 0 (for T) before attempting float/int conversion.
- Existing validation logic (e.g., checking if T > 0, or if R/I are within sensible ranges) will then catch these (now numeric) default values if they are invalid for the scenario.
- This allows the per-scenario error handling mechanism to correctly assign an error message to the specific scenario and for the overall request to complete with a 200 OK status, returning a JSON payload that includes these specific error details.

This change makes the backend data parsing more resilient and should prevent the 400 error, allowing you to see specific input errors instead of a generic bad request.