### PR TITLE
Fix: Add CSRF token handling for compare scenarios AJAX

### DIFF
--- a/project/routes.py
+++ b/project/routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, current_app, request, jsonify, render_template, Response
+from flask_wtf.csrf import generate_csrf
 from flask_babel import gettext, get_locale
 from babel.numbers import format_currency
 import numpy as np
@@ -514,7 +515,7 @@ def compare():
             if request.args.get('W'):
                  first_scenario['enabled'] = True
 
-        return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None, current_year=datetime.datetime.now().year)
+        return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None, current_year=datetime.datetime.now().year, csrf_token=generate_csrf())
 
 @project_blueprint.route('/settings')
 def settings():

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -5,6 +5,7 @@
 {% block head %}
     {{ super() }}
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.15.0/Sortable.min.js"></script>
@@ -300,10 +301,15 @@
             // Log formData for debugging
             // for (var pair of formData.entries()) { console.log(pair[0]+ ': ' + pair[1]); }
 
+            const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
             fetch('/compare', {
                 method: 'POST',
                 body: formData,
-                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRFToken': csrfToken
+                }
             })
             .then(response => {
                 if (!response.ok) {


### PR DESCRIPTION
This commit addresses the HTTP 400 error ("CSRF token missing") on the /compare page when submitting scenario data via AJAX.

Changes:
- project/routes.py:
  - The /compare GET route now generates a CSRF token using flask_wtf.csrf.generate_csrf() and passes it to the template.
- templates/compare.html:
  - Added a <meta name="csrf-token" content="{{ csrf_token }}"> in the head to store the token.
  - JavaScript updated to read this token from the meta tag and include it in the 'X-CSRFToken' header of the fetch POST request to /compare.