### PR TITLE
Fix: Use csrf_token() function in template for CSRF token

### DIFF
--- a/project/routes.py
+++ b/project/routes.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, current_app, request, jsonify, render_template, Response
-from flask_wtf.csrf import generate_csrf
 from flask_babel import gettext, get_locale
 from babel.numbers import format_currency
 import numpy as np
@@ -515,7 +514,7 @@ def compare():
             if request.args.get('W'):
                  first_scenario['enabled'] = True
 
-        return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None, current_year=datetime.datetime.now().year, csrf_token=generate_csrf())
+        return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None, current_year=datetime.datetime.now().year)
 
 @project_blueprint.route('/settings')
 def settings():

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -5,7 +5,7 @@
 {% block head %}
     {{ super() }}
     <meta charset="UTF-8">
-    <meta name="csrf-token" content="{{ csrf_token }}">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <!-- SortableJS will be moved to the end of the body -->


### PR DESCRIPTION
This commit updates the CSRF token handling for the /compare page:

- templates/compare.html:
  - Changed the CSRF meta tag to use `{{ csrf_token() }}` (calling the function) instead of `{{ csrf_token }}` (variable). This is the standard way Flask-WTF provides the token.

- project/routes.py:
  - Removed the explicit passing of `csrf_token=generate_csrf()` to the render_template context for the /compare GET route, as it's no longer needed.
  - Removed the `from flask_wtf.csrf import generate_csrf` import as it's no longer used in this file.

This change aims to resolve issues where the CSRF token was not being correctly rendered into the meta tag.