### PR TITLE
Fix: Explicitly pass CSRF token to compare.html template

### DIFF
--- a/project/routes.py
+++ b/project/routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, current_app, request, jsonify, render_template, Response
+from flask_wtf.csrf import generate_csrf # Re-add this import
 from flask_babel import gettext, get_locale
 from babel.numbers import format_currency
 import numpy as np
@@ -514,7 +515,7 @@ def compare():
             if request.args.get('W'):
                  first_scenario['enabled'] = True
 
-        return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None, current_year=datetime.datetime.now().year)
+        return render_template("compare.html", message="", scenarios=default_scenarios_for_template, combined_balance=None, combined_withdrawal=None, current_year=datetime.datetime.now().year, csrf_token_value=generate_csrf())
 
 @project_blueprint.route('/settings')
 def settings():

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -5,7 +5,7 @@
 {% block head %}
     {{ super() }}
     <meta charset="UTF-8">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="csrf-token" content="{{ csrf_token_value }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <!-- SortableJS will be moved to the end of the body -->


### PR DESCRIPTION
This commit reverts to explicitly passing the CSRF token to the `compare.html` template context and updates the template to use this explicitly passed variable. This is to ensure the CSRF token is reliably available in the template, as issues were encountered with the global `csrf_token()` function in this specific context.

Changes:
- project/routes.py:
  - Re-added `from flask_wtf.csrf import generate_csrf`.
  - The `/compare` GET route now passes `csrf_token_value=generate_csrf()` to `render_template`.
- templates/compare.html:
  - The CSRF meta tag now uses `content="{{ csrf_token_value }}"` to render the token.