### PR TITLE
Fix: Correct template inheritance for CSRF meta tag

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -2,13 +2,10 @@
 
 {% block title %}Compare Financial Scenarios - FIRE Calculator{% endblock %}
 
-{% block head %}
-    {{ super() }}
-    <meta charset="UTF-8">
+{% block head_extra %}
     <meta name="csrf-token" content="{{ csrf_token_value }}">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <!-- SortableJS will be moved to the end of the body -->
+    <!-- SortableJS is loaded at the end of the body -->
     <style>
         .sortable-ghost {
             opacity: 0.4;
@@ -23,7 +20,7 @@
              /* Usually no specific style needed here unless default SortableJS behavior is undesired */
         }
     </style>
-{% endblock %}
+{% endblock head_extra %}
 
 {% block content %}
     <div class="max-w-7xl mx-auto p-4 md:p-8">


### PR DESCRIPTION
This commit updates `templates/compare.html` to use the correct Jinja2 block name (`head_extra`) for inserting head content, ensuring it aligns with `templates/base.html`.

Changes:
- templates/compare.html:
  - Renamed `{% block head %}` to `{% block head_extra %}`.
  - Removed `{{ super() }}` from this block.
  - Removed duplicated charset and viewport meta tags, as they are present in base.html.
  - Ensured the `<meta name="csrf-token" content="{{ csrf_token_value }}">` is within this `head_extra` block.

- project/routes.py:
  - Verified that `csrf_token_value=generate_csrf()` is being explicitly passed to the render_template context for /compare.

This aims to fix the issue where the CSRF meta tag was not being rendered into the final HTML, causing JavaScript errors.