### PR TITLE
Fix: Correct form data key usage in /compare backend

### DIFF
--- a/project/routes.py
+++ b/project/routes.py
@@ -357,8 +357,14 @@ def compare():
         scenarios_data_for_template = []
         for n in range(1, MAX_SCENARIOS_COMPARE + 1):
             scenario_input = {'n': n, 'enabled': form_data.get(f"scenario{n}_enabled") == "on"}
-            for k_form_field in ['W_form', 'r_form', 'i_form', 'T_form', 'D_form', 'withdrawal_time_form']:
-                scenario_input[k_form_field] = form_data.get(f"scenario{n}_{k_form_field.split('_form')[0]}", "")
+
+            # Correctly read core form fields
+            form_field_keys = ['W_form', 'r_form', 'i_form', 'T_form', 'D_form', 'withdrawal_time_form']
+            for key_suffix in form_field_keys:
+                actual_form_data_key = f"scenario{n}_{key_suffix}"
+                value = form_data.get(actual_form_data_key, "")
+                scenario_input[key_suffix] = value # e.g., scenario_input['W_form'] = form_data.get('scenario1_W_form')
+
             for p_num in range(1, 4):
                 for field in ['duration', 'r', 'i']:
                     scenario_input[f'period{p_num}_{field}_form'] = form_data.get(f"scenario{n}_period{p_num}_{field}", "")


### PR DESCRIPTION
This commit fixes an issue in the /compare POST route in `project/routes.py` where core scenario parameters (W, T, r, i, D) were being read from `form_data` using incorrect keys.

The frontend sends keys like `scenario1_W_form`, but the backend was attempting to read them as, for example, `scenario1_W` when populating the `scenario_input` dictionary for fallback calculations and JSON response construction.

This change corrects the loop that populates `scenario_input` to use the full, correct keys (e.g., `form_data.get(f"scenario{n}_W_form")`) ensuring that fallback rates are calculated with the correct data and the summary table reflects the actual inputs. This should resolve the "Time (T) must be > 0" error when using default scenario values.